### PR TITLE
Added CPR configuration option to SC60228 Encoder

### DIFF
--- a/src/encoders/sc60228/MagneticSensorSC60228.cpp
+++ b/src/encoders/sc60228/MagneticSensorSC60228.cpp
@@ -3,7 +3,7 @@
 #include "common/foc_utils.h"
 #include "common/time_utils.h"
 
-MagneticSensorSC60228::MagneticSensorSC60228(int nCS, SPISettings settings) : SC60228(settings, nCS){
+MagneticSensorSC60228::MagneticSensorSC60228(int nCS, uint32_t cpr, SPISettings settings) : SC60228(settings, nCS), cpr_(cpr){
     // nix
 };
 MagneticSensorSC60228::~MagneticSensorSC60228(){ };
@@ -12,7 +12,7 @@ MagneticSensorSC60228::~MagneticSensorSC60228(){ };
 
 float MagneticSensorSC60228::getSensorAngle(){
     SC60228Angle angle_data = readRawAngle();
-    float result = ( angle_data.angle / (float)SC60228_CPR ) * _2PI;
+    float result = ( angle_data.angle / (float)cpr_ ) * _2PI;
     return result;
 };
 

--- a/src/encoders/sc60228/MagneticSensorSC60228.h
+++ b/src/encoders/sc60228/MagneticSensorSC60228.h
@@ -8,12 +8,13 @@
 
 class MagneticSensorSC60228 : public Sensor, public SC60228 {
 public:
-	MagneticSensorSC60228(int nCS = -1, SPISettings settings = SC60228SPISettings);
+	MagneticSensorSC60228(int nCS = -1, uint32_t cpr=4096, SPISettings settings = SC60228SPISettings);
 	virtual ~MagneticSensorSC60228();
 
     virtual float getSensorAngle() override;
 
 	virtual void init(SPIClass* _spi = &SPI) override;
+	uint32_t cpr_;
 };
 
 

--- a/src/encoders/sc60228/README.md
+++ b/src/encoders/sc60228/README.md
@@ -34,7 +34,10 @@ void setup() {
 Set some options:
 
 ```c++
-MagneticSensorSC60228 sensor1(SENSOR1_CS, mySPISettings);
+// set counts_per_revolution (which should be the default 4096, but one some hardware appears to be 2048), and spi settings
+MagneticSensorSC60228 sensor1(SENSOR1_CS, 4096, mySPISettings);
+// or with default SPI settings, just override cpr to a non-default value
+MagneticSensorSC60228 sensor1(SENSOR1_CS, 2048);  
 ```
 
 Use another SPI bus:

--- a/src/encoders/sc60228/SC60228.h
+++ b/src/encoders/sc60228/SC60228.h
@@ -18,7 +18,6 @@ typedef union {
 } SC60228Angle;
 
 
-#define SC60228_CPR 4096
 #define SC60228_BITORDER MSBFIRST
 
 static SPISettings SC60228SPISettings(8000000, SC60228_BITORDER, SPI_MODE1); // @suppress("Invalid arguments")


### PR DESCRIPTION
The SC60228 encoders that I have are reporting 2048 ticks rather than the expected 4096. This is probably an SPI register setting, but I can't find documentation on the chip's register map.

As a solution (interim maybe?) I'm proposing making the encoder ticks a parameter, placing it 2nd in the list since I suspect it's more likely to be overridden than the SPI settings. 