### PR TITLE
Negate zero electrical angle if sensor direction is CCW

### DIFF
--- a/src/encoders/calibrated/CalibratedSensor.cpp
+++ b/src/encoders/calibrated/CalibratedSensor.cpp
@@ -153,7 +153,7 @@ void CalibratedSensor::calibrate(BLDCMotor& motor){
 		if(i==(k*128+96))
 			{
 				_delay(50);
-				avg_elec_angle += _normalizeAngle(_wrapped.getMechanicalAngle()*_NPP);
+				avg_elec_angle += _normalizeAngle(directionSensor*_wrapped.getMechanicalAngle()*_NPP);
 				k += 1;
 			}
 	}


### PR DESCRIPTION
Fix for #24. 

When using the calibration method with the `CalibratedSensor`, the computed zero electrical angle is incorrect if the sensor direction is CCW. This is fixed by negating the computed zero electrical angle if the sensor is CCW (followed by normalizing it to 0-2*PI). After this change, `calibrate` in `CalibratedSensor` returns the same electrical angle as `alignSensor` in `BLDCMotor` for CW and CCW sensor directions.