### PR TITLE
Fixing sensor smoothing when sensor_direction is CCW

### DIFF
--- a/src/encoders/smoothing/SmoothingSensor.cpp
+++ b/src/encoders/smoothing/SmoothingSensor.cpp
@@ -23,7 +23,7 @@ void SmoothingSensor::update() {
   // Perform angle prediction, using low-pass filtered velocity. But don't advance more than
   // pi/3 (equivalent to one step of block commutation) from the last true angle reading.
   float dt = (_micros() - angle_prev_ts) * 1e-6f;
-  angle_prev += _constrain(_motor.shaft_velocity * dt, -_PI_3 / _motor.pole_pairs, _PI_3 / _motor.pole_pairs);
+  angle_prev -= _constrain(_motor.shaft_velocity * dt, -_PI_3 / _motor.pole_pairs, _PI_3 / _motor.pole_pairs);
 
   // Apply phase correction if needed
   if (phase_correction != 0) {

--- a/src/encoders/smoothing/SmoothingSensor.cpp
+++ b/src/encoders/smoothing/SmoothingSensor.cpp
@@ -23,12 +23,12 @@ void SmoothingSensor::update() {
   // Perform angle prediction, using low-pass filtered velocity. But don't advance more than
   // pi/3 (equivalent to one step of block commutation) from the last true angle reading.
   float dt = (_micros() - angle_prev_ts) * 1e-6f;
-  angle_prev -= _constrain(_motor.shaft_velocity * dt, -_PI_3 / _motor.pole_pairs, _PI_3 / _motor.pole_pairs);
+  angle_prev += _motor.sensor_direction * _constrain(_motor.shaft_velocity * dt, -_PI_3 / _motor.pole_pairs, _PI_3 / _motor.pole_pairs);
 
   // Apply phase correction if needed
   if (phase_correction != 0) {
-    if (_motor.shaft_velocity < -0) angle_prev -= phase_correction / _motor.pole_pairs;
-    else if (_motor.shaft_velocity > 0) angle_prev += phase_correction / _motor.pole_pairs;
+    if (_motor.shaft_velocity < -0) angle_prev -= _motor.sensor_direction * phase_correction / _motor.pole_pairs;
+    else if (_motor.shaft_velocity > 0) angle_prev += _motor.sensor_direction * phase_correction / _motor.pole_pairs;
   }
 
   // Handle wraparound of the projected angle


### PR DESCRIPTION
Using motor.sensor_direction so the smoothing works on both sensor directions.
It was discussed with dekutree64.
Tested it by swapping phases to make sure it works in both directions.