### PR TITLE
Fix compiler warning in MT6835.cpp

### DIFF
--- a/src/encoders/mt6835/MT6835.cpp
+++ b/src/encoders/mt6835/MT6835.cpp
@@ -91,7 +91,7 @@ uint8_t MT6835::getStatus(){
 uint8_t MT6835::getCalibrationStatus(){
     uint8_t data[3] = {0};
     data[0] = MT6835_OP_READ << 4 | MT6835_REG_CAL_STATUS >> 8;
-    data[1] = MT6835_REG_CAL_STATUS;
+    data[1] = MT6835_REG_CAL_STATUS & 0xFF;
 
     spi->beginTransaction(settings);
     if(nCS >= 0)


### PR DESCRIPTION
This change fixes a warning about an implicit overflow of `MT6835_REG_CAL_STATUS`.

```
unsigned conversion from 'int' to 'uint8_t' {aka 'unsigned char'} changes value from '275' to '19' [-Werror=overflow]
```