### PR TITLE
Update AS5600.cpp

### DIFF
--- a/src/encoders/as5600/AS5600.cpp
+++ b/src/encoders/as5600/AS5600.cpp
@@ -124,13 +124,13 @@ void AS5600::setZPos(uint16_t value) {
 void AS5600::setI2CAddr(uint8_t value) {
     uint8_t val = (uint8_t)readRegister(AS5600_REG_I2CADDR, 1);
     val = (value<<1) | (val&0x01);
-    writeRegister(AS5600_REG_I2CADDR, val);
+    writeRegister(AS5600_REG_I2CADDR, val, 1);
 };
 
 void AS5600::setI2CUpdt(uint8_t value) {
     uint8_t val = (uint8_t)readRegister(AS5600_REG_I2CUPDT, 1);
     val = (value<<1) | (val&0x01);
-    writeRegister(AS5600_REG_I2CUPDT, val);
+    writeRegister(AS5600_REG_I2CUPDT, val, 1);
 };
 
 


### PR DESCRIPTION
Critical bug fix. The I2CADDR and I2CUPDT registers are single byte registers on AS5600L, without specifying this the default behaviour is to write two bytes. The address will then be mistakenly written as 0x00 which is a reserved I2C address. If this is followed by a burn settings, the wrong address may permanently be written and the sensor may be 'bricked'.