### PR TITLE
Type casting bug in STM32HWEncoder fixed

### DIFF
--- a/src/encoders/stm32hwencoder/STM32HWEncoder.cpp
+++ b/src/encoders/stm32hwencoder/STM32HWEncoder.cpp
@@ -5,7 +5,7 @@
 /*
   HardwareEncoder(int cpr)
 */
-STM32HWEncoder::STM32HWEncoder(unsigned int _ppr, int8_t pinA, int8_t pinB, int8_t pinI) {
+STM32HWEncoder::STM32HWEncoder(unsigned int _ppr, int pinA, int pinB, int pinI) {
     cpr = _ppr * 4; // 4x for quadrature
     _pinA = digitalPinToPinName(pinA);
     _pinB = digitalPinToPinName(pinB);

--- a/src/encoders/stm32hwencoder/STM32HWEncoder.h
+++ b/src/encoders/stm32hwencoder/STM32HWEncoder.h
@@ -16,7 +16,7 @@ class STM32HWEncoder : public Sensor {
     Encoder class constructor
     @param ppr  impulses per rotation  (cpr=ppr*4)
     */
-    explicit STM32HWEncoder(unsigned int ppr, int8_t pinA, int8_t pinB, int8_t pinI=-1);
+    explicit STM32HWEncoder(unsigned int ppr, int pinA, int pinB, int pinI=-1);
 
     void init() override;
     int needsSearch() override;


### PR DESCRIPTION
Hello,

Found this bug while trying to get this code to work:

```
STM32HWEncoder e(1000, PA0, PA1);
```

This is the related part of my `platformio.ini` config:

```
platform = ststm32
board = nucleo_g474re
framework = arduino
```

In this case, PA0 is 192 and PA1 is 193. Currently, when you pass pins to the `STM32HWEncoder` constructor, they're trimmed down to the `int8_t`, which is incorrect. In my case 192 and 193 do not actually fit into the `int8_t`, and trimming then leads to incorrect operation of the `digitalPinToPinName` function. So I just changed `int8_t` to `int`