### PR TITLE
CalibratedSensor: settle time as parameter

### DIFF
--- a/src/encoders/calibrated/CalibratedSensor.h
+++ b/src/encoders/calibrated/CalibratedSensor.h
@@ -23,7 +23,7 @@ public:
     /**
     * Calibrate method computes the LUT for the correction
     */
-    virtual void calibrate(FOCMotor& motor, float* lut = nullptr, float zero_electric_angle = 0.0, Direction senor_direction= Direction::CW);
+    virtual void calibrate(FOCMotor& motor, float* lut = nullptr, float zero_electric_angle = 0.0, Direction senor_direction= Direction::CW, int settle_time_ms = 30);
 
     // voltage to run the calibration: user input
     float voltage_calibration = 1;    


### PR DESCRIPTION
Hi,
I had some problems with the CalibratedSensor class when using with the new HybridStepper functionality. 
Solution was to increase the settle time but as it was hard coded i made it a parameter. 
Also my Encoder (which is a standard Mag enocoder with quadrature A/B interface) did output negative values with the `getMechanicalAngle`-API which made the LUT not work when turning negative. I added a `fmodf` call to prevent that. 