### PR TITLE
Feat pwm input update

### DIFF
--- a/src/comms/stm32speeddir/README.md
+++ b/src/comms/stm32speeddir/README.md
@@ -21,6 +21,10 @@ The direction input is optional - if not provided, you can control the direction
 
 The velocity values returned are in the range `min_speed` to `max_speed`, while the input PWM duty cycle should lie within the range `min_pwm` to `max_pwm`. Actual input values smaller than `min_pwm` will be treated as `min_pwm`, values larger than `max_pwm` will be treated as `max_pwm`. The behaviour for 100% or 0% duty cycles is undefined, and they should be avoided.
 
+> **IMPORTANT**<br>
+> If the PWM frequency of the speed input is not known, provide its value in Hz to the constructor. If not provided, it will default to 1kHz (very common value). The frequency is used to make sure that the PWM period stays within one timer counter period. If this is not the case the timer counter can overflow and the input will not work correctly.
+
+
 ## Usage
 
 Use it like this:
@@ -31,8 +35,9 @@ Use it like this:
 // some example pins - the speed pin has to be on channel 1 or 2 of a timer
 #define PIN_SPEED PC6
 #define PIN_DIRECTION PB8
+#define PWM_FREQUENCY 1000 // 1kHz (defualt)
 
-STM32SpeedDirInput speed_dir = STM32SpeedDirInput(PIN_SPEED, PIN_DIRECTION);
+STM32SpeedDirInput speed_dir = STM32SpeedDirInput(PIN_SPEED, PIN_DIRECTION, PWM_FREQUENCY);
 
 float target = 0.0f;
 

--- a/src/comms/stm32speeddir/STM32SpeedDirInput.cpp
+++ b/src/comms/stm32speeddir/STM32SpeedDirInput.cpp
@@ -3,7 +3,7 @@
 
 #if defined(_STM32_DEF_)
 
-STM32SpeedDirInput::STM32SpeedDirInput(int pin_speed, int pin_dir) : STM32PWMInput(pin_speed) {
+STM32SpeedDirInput::STM32SpeedDirInput(int pin_speed, int pin_dir, uint32_t pwm_freq) : STM32PWMInput(pin_speed, _pwm_freq) {
     _pin_speed = pin_speed;
     _pin_dir = pin_dir;
 };

--- a/src/comms/stm32speeddir/STM32SpeedDirInput.h
+++ b/src/comms/stm32speeddir/STM32SpeedDirInput.h
@@ -10,7 +10,21 @@
 
 class STM32SpeedDirInput : public STM32PWMInput {
     public:
-        STM32SpeedDirInput(int pin_speed, int pin_dir = NOT_SET);
+
+        /**
+         * STM32SpeedDirInput constructor
+         * 
+         * @param pin_speed - the pin number to read the speed PWM signal from
+         * @param pin_dir - the pin number to read the direction signal from (default is NOT_SET)
+         * @param pwm_freq - the frequency of the PWM signal (default is 1kHz)
+         * 
+         * This class is used to read speed and direction signals from a pin using the STM32 HAL library.
+         * IMPORTANT!
+         *      This class can only be used with the pins that are associated with some timer,
+         *      and only if they are associated to the channels 1 or 2. The timer can not be
+         *      used for other purposes, like motor control.
+         */
+        STM32SpeedDirInput(int pin_speed, int pin_dir = NOT_SET, uint32_t pwm_freq = 1000);
         ~STM32SpeedDirInput();
 
         int init();

--- a/src/encoders/stm32pwmsensor/README.md
+++ b/src/encoders/stm32pwmsensor/README.md
@@ -21,10 +21,18 @@ sensor.getDutyCycleTicks();
 
 By rotating the motor through several full turns while printing the ticks to the screen you will be able to determine the correct values empirically.
 
+
+> **IMPORTANT**<br>
+> If the PWM frequency of the speed input is not known, provide its value in Hz to the constructor. If not provided, it will default to 1kHz (very common value). The frequency is used to make sure that the PWM period stays within one timer counter period. If this is not the case the timer counter can overflow and the input will not work correctly.
+
+
 ## Usage
 
 ```
-STM32MagneticSensorPWM sensor = STM32MagneticSensorPWM(PB7, 412, 6917); // sample values, yours will be different
+
+#define PWM_FREQ_HZ 1000 // 1kHz (default)
+
+STM32MagneticSensorPWM sensor = STM32MagneticSensorPWM(PB7, 412, 6917, PWM_FREQ_HZ); // sample values, yours will be different
 
 void setup() {
     ...

--- a/src/encoders/stm32pwmsensor/STM32MagneticSensorPWM.cpp
+++ b/src/encoders/stm32pwmsensor/STM32MagneticSensorPWM.cpp
@@ -6,7 +6,7 @@
 #include "common/foc_utils.h"
 
 
-STM32MagneticSensorPWM::STM32MagneticSensorPWM(int pin, uint32_t _min_ticks, uint32_t _max_ticks) : STM32PWMInput(pin), max_ticks(_max_ticks), min_ticks(_min_ticks) {
+STM32MagneticSensorPWM::STM32MagneticSensorPWM(int pin, uint32_t _min_ticks, uint32_t _max_ticks, uint32_t _pwm_freq) : STM32PWMInput(pin), max_ticks(_max_ticks), min_ticks(_min_ticks) {
 
 };
 

--- a/src/encoders/stm32pwmsensor/STM32MagneticSensorPWM.h
+++ b/src/encoders/stm32pwmsensor/STM32MagneticSensorPWM.h
@@ -13,7 +13,7 @@
 
 class STM32MagneticSensorPWM : public Sensor, public STM32PWMInput {
     public:
-        STM32MagneticSensorPWM(int pin, uint32_t _min_ticks = 0, uint32_t _max_ticks = 0x0FFF);
+        STM32MagneticSensorPWM(int pin, uint32_t _min_ticks = 0, uint32_t _max_ticks = 0x0FFF, uint32_t _pwm_freq = 1000);
         ~STM32MagneticSensorPWM();
 
         void init() override;

--- a/src/utilities/stm32pwm/STM32PWMInput.h
+++ b/src/utilities/stm32pwm/STM32PWMInput.h
@@ -7,19 +7,48 @@
 
 class STM32PWMInput {
     public:
-        STM32PWMInput(int pin);
+        /**
+         * StM32PWMInput constructor
+         * 
+         * @param pin - the pin number to read the PWM signal from
+         * @param pwm_freq - the frequency of the PWM signal (default is 1kHz)
+         * 
+         * This class is used to read PWM signals from a pin using the STM32 HAL library.
+         * IMPORTANT!
+         *     This class can only be used with the pins that are assocaited with some timer, 
+         *     and only if they are associated to the channels 1 or 2. The timer can not be 
+         *     used for other purposes, like motor control. 
+         */
+        STM32PWMInput(int pin, uint32_t pwm_freq = 1000);
         ~STM32PWMInput();
 
         int initialize();
 
+        /**
+         * Get the duty cycle of the PWM signal as a percentage.
+         * 
+         * @return float - the duty cycle in percent
+         */
         float getDutyCyclePercent();
+        /**
+         * Get the duty cycle of the PWM signal in ticks.
+         * 
+         * @return uint32_t - the duty cycle in ticks
+         */
         uint32_t getDutyCycleTicks();
+        /**
+         * Get the period of the PWM signal in ticks.
+         * 
+         * @return uint32_t - the period in ticks
+         */
         uint32_t getPeriodTicks();
         
-        PinName _pin;
+        PinName _pin; // the pin to read the PWM signal from 
+        uint32_t _pwm_freq; // the frequency of the PWM signal
+
     protected:
-        TIM_HandleTypeDef timer;
-        bool useChannel2 = false;
+        TIM_HandleTypeDef timer; // the timer handle for the PWM input
+        bool useChannel2 = false; // whether to use channel 2 or not, default is channel 1
 };
 
 


### PR DESCRIPTION
Update and testing of the PWM input sensor. 

I've tested it on f411re nucleo on 16bit and 32bit timers. it seems to work well. 

**The big change:**
Added the PWM frequency parameter to the constructors. The rationale is that in some cases, if the PWM frequency of is low (for example 1kHz) the timer period can be shorter than the PWM period and the overflow can happen. 
So I've added a short code that updates the prescaler of the timer to make sure that the timer counter period is always longer than the PWM period (provided in the constructors). 
This parameter is optional, and the defualt value is 1kHz that is quite common as far as I know. But this can be changed of course.

 