### PR TITLE
esp32: fix compilation on models without a pcnt peripheral

### DIFF
--- a/src/encoders/esp32hwencoder/ESP32HWEncoder.cpp
+++ b/src/encoders/esp32hwencoder/ESP32HWEncoder.cpp
@@ -1,6 +1,6 @@
 #include "ESP32HWEncoder.h"
 
-#if defined(ESP_H) && defined(ARDUINO_ARCH_ESP32)
+#if defined(ESP_H) && defined(ARDUINO_ARCH_ESP32) && defined(CONFIG_SOC_PCNT_SUPPORTED)
 
 
 

--- a/src/encoders/esp32hwencoder/ESP32HWEncoder.h
+++ b/src/encoders/esp32hwencoder/ESP32HWEncoder.h
@@ -5,7 +5,8 @@
 
 
 #if defined(ESP_H) && defined(ARDUINO_ARCH_ESP32)
-
+#include "sdkconfig.h"
+#if defined(CONFIG_SOC_PCNT_SUPPORTED)
 #include "driver/pcnt.h"
 #include "soc/pcnt_struct.h"
 #include "common/base_classes/Sensor.h"
@@ -62,5 +63,5 @@ class ESP32HWEncoder : public Sensor{
         int32_t cpr; // Counts per rotation = 4 * ppr for quadrature encoders
         float inv_cpr;
 };
-
+#endif
 #endif


### PR DESCRIPTION
On the esp32c3, the drivers wouldn't compile because of this file, as it doesn't have a pcnt peripheral.

This fixes that.