### PR TITLE
stspin32g4: Add bootstrap capacitor charge mode on enable to avoid high side UVLO error on enable

### DIFF
--- a/src/drivers/stspin32g4/STSPIN32G4.cpp
+++ b/src/drivers/stspin32g4/STSPIN32G4.cpp
@@ -37,10 +37,45 @@ int STSPIN32G4::init(){
 
     // TODO init fault monitor
 
+    bootstrap_charge();
+
     return isReady() ? 1 : 0;
 };
 
+void STSPIN32G4::enable()
+{
+    bootstrap_charge();
+    BLDCDriver6PWM::enable();
+}
 
+
+void STSPIN32G4::bootstrap_charge()
+{
+    //store phase states, enable low side drive
+    static const int num_phases = sizeof(phase_state)/sizeof(phase_state[0]);
+    PhaseState phase_state_before[num_phases];
+    bool none_disabled = true;
+    for (size_t i = 0; i < num_phases; i++)
+    {
+        phase_state_before[i] = phase_state[i];
+        if (phase_state[i] == PHASE_HI || phase_state[i] == PHASE_OFF)
+        {
+            none_disabled = false;
+        }
+    }
+    if (none_disabled)
+    {
+        return;
+    }
+    setPhaseState(PHASE_LO, PHASE_LO, PHASE_LO);
+    setPwm(0,0,0);
+    _delay(bootstrap_capacitor_charge_time);
+    //restore phase states
+    for (size_t i = 0; i < num_phases; i++)
+    {
+        phase_state[i] = phase_state_before[i];
+    }
+}
 
 void STSPIN32G4::wake() {
     digitalWrite(STSPIN32G4_PIN_WAKE, HIGH);

--- a/src/drivers/stspin32g4/STSPIN32G4.h
+++ b/src/drivers/stspin32g4/STSPIN32G4.h
@@ -116,8 +116,13 @@ public:
     STSPIN32G4();
     ~STSPIN32G4();
 
+    unsigned int bootstrap_capacitor_charge_time = 10; //time to let the bootstrap capacitors charge for, in ms. During his time, brakes are applied. This is not necessary if the motor is rotating, as the BEMF allows the caps to charge.
+
     int init() override;
 
+    void enable() override;
+
+    void bootstrap_charge();
     void wake();
     void sleep();
     bool isReady();


### PR DESCRIPTION
This overrides the enable sequence on the stspin32g4:

The capacitors for the high side FETs need to be charged to drive the outputs high. Capacitors are charged by driving the low side mosfets ON.

If the voltage on the bootstrap capacitor goes below 5V while asking for the high side mosfet to be ON, this causes an undervoltage lockout on the high side FET, making them not conduct.

The high side UVLO isn't communicated back to the driver, as it's floating circuitry. But the Vds protection kick in, causing an error and disabling everything.

This adds a time when enabling where all the low side FETs are enabled, allowing for the caps to charge.