### PR TITLE
CalibratedSensor: Allow calibration with provided lut

### DIFF
--- a/src/encoders/calibrated/CalibratedSensor.cpp
+++ b/src/encoders/calibrated/CalibratedSensor.cpp
@@ -101,12 +101,11 @@ void CalibratedSensor::calibrate(FOCMotor &motor, int settle_time_ms)
 {
 	// if the LUT is already defined, skip the calibration
 
-	if(calibrationLut == NULL) {
+	if (calibrationLut == NULL) {
 		allocated = true;
 		calibrationLut = new uint16_t[n_lut];
-	}else{
-		SIMPLEFOC_DEBUG("SEN_CAL: Using pre-defined LUT for calibration.");
-		return;
+	} else {
+		SIMPLEFOC_DEBUG("SEN_CAL: Overwriting pre-defined LUT for calibration.");
 	}
 	SIMPLEFOC_DEBUG("SEN_CAL: Starting Sensor Calibration.");
 

--- a/src/encoders/calibrated/README.md
+++ b/src/encoders/calibrated/README.md
@@ -125,7 +125,7 @@ If you calibrate once during setup and save the LUT to EEPROM or hardcode it, yo
 
 1. **First run**: Call `calibrate(motor)` → Serial outputs LUT
 2. **Copy LUT**: Paste the generated values into your code
-3. **Subsequent runs**: Pass LUT to constructor and `calibrate()` → instantaneous, no rotation needed
+3. **Subsequent runs**: Pass LUT to constructor and DO NOT call `calibrate()` → instantaneous, no rotation needed
 
 Your code will look something like this:
 


### PR DESCRIPTION
Hi,

I think i found a logic error. The return in calibrate prevents providing a lut and writing to it and since the allocated lut is protected in the class there is no way to extract at runtime.

The README:150 already suggests not calling calibrate when you provide a valid lut.

...and sry for not updating the README.md correctly last PR :/ 