### PR TITLE
Improve mt6816 angle reading efficiency

### DIFF
--- a/src/encoders/mt6816/MT6816.cpp
+++ b/src/encoders/mt6816/MT6816.cpp
@@ -18,8 +18,24 @@ void MT6816::init(SPIClass* _spi) {
 
 uint16_t MT6816::readRawAngle()  {
     uint16_t angle_data = 0;
-    angle_data = spi_transfer16(MT6816_READ_REG_03) << 8;
-    angle_data |= spi_transfer16(MT6816_READ_REG_04);
+    uint8_t data[3] = {0};
+
+    data[0] = 0x83; // command to read MSB
+    data[1] = 0;
+    data[2] = 0;
+
+    spi->beginTransaction(settings);
+    if (nCS>=0)
+        digitalWrite(nCS, 0);
+
+    spi->transfer(data, 3);
+
+    if (nCS>=0)
+        digitalWrite(nCS, 1);
+    spi->endTransaction();
+
+    angle_data = (data[1] & 0xFF) << 8;
+    angle_data |= (data[2] & 0xFF);
 
     if ((angle_data & MT6816_NO_MAGNET_WARNING_BIT) == MT6816_NO_MAGNET_WARNING_BIT) {
         this->no_magnetic_reading = true;
@@ -31,7 +47,7 @@ uint16_t MT6816::readRawAngle()  {
         return 0;
     }
 
-    return (angle_data >> 2);
+    return (angle_data >> 2) & 0x3FFF; // 14 bits of angle data
 }
 
 bool MT6816::parityCheck(uint16_t data) {
@@ -41,16 +57,4 @@ bool MT6816::parityCheck(uint16_t data) {
     data ^= data >> 1;
 
     return (~data) & 1;
-}
-
-uint16_t MT6816::spi_transfer16(uint16_t outdata) {
-    spi->beginTransaction(settings);
-    if (nCS>=0)
-        digitalWrite(nCS, 0);
-    uint16_t result = spi->transfer16(outdata);
-    if (nCS>=0)
-        digitalWrite(nCS, 1);
-    spi->endTransaction();
-
-    return result;
 }

--- a/src/encoders/mt6816/MT6816.h
+++ b/src/encoders/mt6816/MT6816.h
@@ -30,7 +30,6 @@ public:
 
 private:
     bool parityCheck(uint16_t data);
-    uint16_t spi_transfer16(uint16_t outdata);
     SPIClass* spi;
     SPISettings settings;
     bool no_magnetic_reading = false;


### PR DESCRIPTION
It's a bit slow to send two reading commands for reading one angle value. We should take advantage of the "burst read" according to its datasheet.