### PR TITLE
Make CANCommander compile only when SimpleCANio.h exists

### DIFF
--- a/src/comms/can/CANCommander.cpp
+++ b/src/comms/can/CANCommander.cpp
@@ -1,4 +1,4 @@
-#if __has_include("SimpleCANio.h")
+#if has_SimpleCANio
 #include "CANCommander.h"
 
 CANCommander::CANCommander(HardwareCAN& can, uint8_t addr, bool echo_enabled, int baudrate, bool no_filter) 

--- a/src/comms/can/CANCommander.cpp
+++ b/src/comms/can/CANCommander.cpp
@@ -1,3 +1,4 @@
+#if __has_include("SimpleCANio.h")
 #include "CANCommander.h"
 
 CANCommander::CANCommander(HardwareCAN& can, uint8_t addr, bool echo_enabled, int baudrate, bool no_filter) 
@@ -191,3 +192,5 @@ RegisterIO& CANCommander::operator>>(float& value) {
     }
     return *this;
 }
+
+#endif

--- a/src/comms/can/CANCommander.h
+++ b/src/comms/can/CANCommander.h
@@ -1,5 +1,6 @@
 #ifndef CANCOMMANDER_H 
 #define CANCOMMANDER_H
+#if __has_include("SimpleCANio.h")
 
 #include "SimpleFOC.h"
 #include "../SimpleFOCRegisters.h"
@@ -82,4 +83,5 @@ protected:
     uint8_t rx_available = 0;
 };
 
+#endif
 #endif

--- a/src/comms/can/CANCommander.h
+++ b/src/comms/can/CANCommander.h
@@ -1,7 +1,12 @@
 #ifndef CANCOMMANDER_H 
 #define CANCOMMANDER_H
-#if __has_include("SimpleCANio.h")
+#if __cplusplus >= 201703L //Check for C++17 or later
+    #if __has_include("SimpleCANio.h") //C++17 required for __has_include
+        #define has_SimpleCANio 1
+    #endif
+#endif
 
+#ifdef has_SimpleCANio
 #include "SimpleFOC.h"
 #include "../SimpleFOCRegisters.h"
 #include "../RegisterIO.h"


### PR DESCRIPTION
This addresses https://github.com/simplefoc/Arduino-FOC-drivers/issues/87