### PR TITLE
Add Phoque1 current sense, lighten Phoque2 current sense code

### DIFF
--- a/src/current_sense/phoque/Phoque_CurrentSense.cpp
+++ b/src/current_sense/phoque/Phoque_CurrentSense.cpp
@@ -306,7 +306,7 @@ int Phoque_CurrentSense::driverAlign(float align_voltage, bool modulation_center
 {
 	_UNUSED(align_voltage);
 	_UNUSED(modulation_centered);
-	return 0;
+	return 1;
 }
 
 extern "C" {

--- a/src/current_sense/phoque/Phoque_CurrentSense.cpp
+++ b/src/current_sense/phoque/Phoque_CurrentSense.cpp
@@ -5,7 +5,7 @@
 #include <current_sense/hardware_specific/stm32/stm32_adc_utils.h>
 
 static constexpr float adc_voltage = 3.3f;
-static constexpr float adc_resolution = 4095.f;
+static constexpr int adc_resolution = 4095;
 
 static ADC_HandleTypeDef hadc1;
 static ADC_HandleTypeDef hadc2;
@@ -13,18 +13,19 @@ static ADC_HandleTypeDef hadc2;
 static DMA_HandleTypeDef hdma_adc1;
 static DMA_HandleTypeDef hdma_adc2;
 
+#define PHOQUE_CS_DEBUG "PHOQUE-CS: "
+
 Phoque_CurrentSense::Phoque_CurrentSense(float _shunt_resistor, float _gain, bool _read_bemf)
 	:read_bemf(_read_bemf)
 {
 	gain_c = gain_b = gain_a = 1.0f /_shunt_resistor / _gain;
-	skip_align = true;
 }
 
 Phoque_CurrentSense::Phoque_CurrentSense(float _mVpA, bool _read_bemf)
 	:read_bemf(_read_bemf)
 {
+	//Convert millivolts per amp to amps per volt
 	gain_c = gain_b = gain_a = 1000.f/_mVpA;
-	skip_align = true;
 }
 
 Phoque_CurrentSense::~Phoque_CurrentSense()
@@ -32,7 +33,6 @@ Phoque_CurrentSense::~Phoque_CurrentSense()
 	if (initialized)
 	{
 		delete[] adc1_buffer;
-		delete[] adc2_buffer;
 	}
 	
 }
@@ -47,7 +47,7 @@ void Phoque_CurrentSense::GPIO_Init()
 	__HAL_RCC_ADC12_CLK_ENABLE();
 }
 
-void Phoque_CurrentSense::DMA_Init() 
+void Phoque_CurrentSense::DMA_InitClock() 
 {
 	/* DMA controller clock enable */
 	__HAL_RCC_DMAMUX1_CLK_ENABLE();
@@ -76,11 +76,17 @@ void Phoque_CurrentSense::OPAMP_Init()
 	//do nothing
 }
 
+int Phoque_CurrentSense::get_conversion_duration(int sample_ticks) const
+{
+	//12.5 ticks of SAR @ 12bits, + half tick of sample
+	return sample_ticks + 13;
+}
+
 int Phoque_CurrentSense::ADC1_Init(ADC_HandleTypeDef* hadc1)
 {
 	ADC_MultiModeTypeDef multimode = {0};
 	hadc1->Instance = ADC1;
-	hadc1->Init.ClockPrescaler = ADC_CLOCK_ASYNC_DIV8;
+	hadc1->Init.ClockPrescaler = ADC_CLOCK_SYNC_PCLK_DIV4;
 	hadc1->Init.Resolution = ADC_RESOLUTION_12B;
 	hadc1->Init.DataAlign = ADC_DATAALIGN_RIGHT;
 	hadc1->Init.GainCompensation = 0;
@@ -97,7 +103,7 @@ int Phoque_CurrentSense::ADC1_Init(ADC_HandleTypeDef* hadc1)
 
 	if (HAL_ADC_Init(hadc1) != HAL_OK)
 	{
-		SIMPLEFOC_DEBUG("HAL_ADC_Init failed!");
+		SIMPLEFOC_DEBUG(PHOQUE_CS_DEBUG "HAL_ADC_Init failed!");
 	}
 
 	/** Configure the ADC multi-mode 
@@ -105,7 +111,7 @@ int Phoque_CurrentSense::ADC1_Init(ADC_HandleTypeDef* hadc1)
 	multimode.Mode = ADC_MODE_INDEPENDENT;
 	if (HAL_ADCEx_MultiModeConfigChannel(hadc1, &multimode) != HAL_OK)
 	{
-		SIMPLEFOC_DEBUG("HAL_ADCEx_MultiModeConfigChannel 1 failed!");
+		SIMPLEFOC_DEBUG(PHOQUE_CS_DEBUG "HAL_ADCEx_MultiModeConfigChannel 1 failed!");
 	}
 
 	return 0;
@@ -114,7 +120,7 @@ int Phoque_CurrentSense::ADC1_Init(ADC_HandleTypeDef* hadc1)
 int Phoque_CurrentSense::ADC2_Init(ADC_HandleTypeDef* hadc2)
 {
 	hadc2->Instance = ADC2;
-	hadc2->Init.ClockPrescaler = ADC_CLOCK_ASYNC_DIV8;
+	hadc2->Init.ClockPrescaler = ADC_CLOCK_SYNC_PCLK_DIV4;
 	hadc2->Init.Resolution = ADC_RESOLUTION_12B;
 	hadc2->Init.DataAlign = ADC_DATAALIGN_RIGHT;
 	hadc2->Init.GainCompensation = 0;
@@ -124,20 +130,20 @@ int Phoque_CurrentSense::ADC2_Init(ADC_HandleTypeDef* hadc2)
 	hadc2->Init.ContinuousConvMode = DISABLE;
 
 	hadc2->Init.DiscontinuousConvMode = DISABLE;
-	hadc2->Init.ExternalTrigConv = ADC_EXTERNALTRIG_T1_TRGO;
+	hadc2->Init.ExternalTrigConv = ADC_EXTERNALTRIG_T1_TRGO2;
 	hadc2->Init.ExternalTrigConvEdge = ADC_EXTERNALTRIGCONVEDGE_RISING;
 	hadc2->Init.DMAContinuousRequests = ENABLE;
 	hadc2->Init.Overrun = ADC_OVR_DATA_PRESERVED;
 
 	if (HAL_ADC_Init(hadc2) != HAL_OK)
 	{
-		SIMPLEFOC_DEBUG("HAL_ADC_Init failed!");
+		SIMPLEFOC_DEBUG(PHOQUE_CS_DEBUG "HAL_ADC_Init failed!");
 	}
 
 	return 0;
 }
 
-void Phoque_CurrentSense::DMA1_Init(ADC_HandleTypeDef *hadc, DMA_HandleTypeDef *hdma_adc, DMA_Channel_TypeDef* channel, uint32_t request)
+void Phoque_CurrentSense::DMA_Init(ADC_HandleTypeDef *hadc, DMA_HandleTypeDef *hdma_adc, DMA_Channel_TypeDef* channel, uint32_t request)
 {
 	hdma_adc->Instance = channel;
 	hdma_adc->Init.Request = request;
@@ -151,7 +157,7 @@ void Phoque_CurrentSense::DMA1_Init(ADC_HandleTypeDef *hadc, DMA_HandleTypeDef *
 	HAL_DMA_DeInit(hdma_adc);
 	if (HAL_DMA_Init(hdma_adc) != HAL_OK)
 	{
-		SIMPLEFOC_DEBUG("HAL_DMA_Init failed!");
+		SIMPLEFOC_DEBUG(PHOQUE_CS_DEBUG "HAL_DMA_Init failed!");
 	}
 	__HAL_LINKDMA(hadc, DMA_Handle, *hdma_adc);
 }
@@ -160,6 +166,7 @@ void* Phoque_CurrentSense::SyncLowSide(void* _driver_params, void* _cs_params)
 {
 	STM32DriverParams* driver_params = (STM32DriverParams*)_driver_params;
 	Stm32CurrentSenseParams* cs_params = (Stm32CurrentSenseParams*)_cs_params;
+	TIM_TypeDef *instance = cs_params->timer_handle->Instance;
 	 
 	// stop all the timers for the driver
 	stm32_pause(driver_params);
@@ -170,11 +177,59 @@ void* Phoque_CurrentSense::SyncLowSide(void* _driver_params, void* _cs_params)
 	bool tim_interrupt = _initTimerInterruptDownsampling(cs_params, driver_params, adc_int_config);
 	if(tim_interrupt) {
 	// error in the timer interrupt initialization
-		SIMPLEFOC_DEBUG("STM32-CS: timer has no repetition counter, ADC interrupt not supported for this Phoque");
+		SIMPLEFOC_DEBUG(PHOQUE_CS_DEBUG "timer has no repetition counter, ADC interrupt not supported for this Phoque");
 		return SIMPLEFOC_CURRENT_SENSE_INIT_FAILED;
 	}
+	uint32_t adc_ccr = ADC12_COMMON->CCR;
+	uint32_t adc_prescaler;
+	if (adc_ccr & ADC_CCR_CKMODE_Msk)
+	{
+		//sync mode
+		uint8_t adc_prescalers[] = {1, 1, 2, 4};
+		adc_prescaler = adc_prescalers[(adc_ccr & ADC_CCR_CKMODE_Msk) >> ADC_CCR_CKMODE_Pos];
+	}
+	else
+	{
+		//async mode
+		uint16_t adc_prescalers[] = {1, 2, 4, 6, 8, 10, 12, 16, 32, 64, 128, 256};
+		adc_prescaler = adc_prescalers[(adc_ccr & ADC_CCR_PRESC_Msk) >> ADC_CCR_PRESC_Pos];
+	}
+	
+	uint32_t adc_clock_freq = HAL_RCCEx_GetPeriphCLKFreq(RCC_PERIPHCLK_ADC12) / adc_prescaler;
+	uint32_t timer_clock_freq = stm32_getTimerClockFreq(cs_params->timer_handle) / (cs_params->timer_handle->Instance->PSC +1);
+	uint32_t adc1_center = (uint64_t)get_adc1_important_duration() * timer_clock_freq / adc_clock_freq / 2;
+	uint32_t adc2_center = (uint64_t)get_adc2_important_duration() * timer_clock_freq / adc_clock_freq / 2;
+
 	// set the trigger output event
-	LL_TIM_SetTriggerOutput(cs_params->timer_handle->Instance, LL_TIM_TRGO_UPDATE);
+	LL_TIM_OC_InitTypeDef oc_init = {
+		.OCMode = LL_TIM_OCMODE_PWM2,
+		.OCState = LL_TIM_OCSTATE_DISABLE,
+		.OCNState = LL_TIM_OCSTATE_DISABLE,
+		.CompareValue = instance->ARR-adc1_center,
+		.OCPolarity = LL_TIM_OCPOLARITY_HIGH,
+		.OCNPolarity = LL_TIM_OCPOLARITY_HIGH,
+		.OCIdleState = LL_TIM_OCIDLESTATE_LOW,
+		.OCNIdleState = LL_TIM_OCIDLESTATE_LOW,
+	};
+	if (adc1_center > 0)
+	{
+		LL_TIM_OC_Init(instance, LL_TIM_CHANNEL_CH4, &oc_init);
+		LL_TIM_SetTriggerOutput(instance, LL_TIM_TRGO_OC4REF);
+	}
+	else
+	{
+		LL_TIM_SetTriggerOutput(instance, LL_TIM_TRGO_UPDATE);
+	}
+	if (adc2_center > 0)
+	{
+		oc_init.CompareValue = instance->ARR-adc2_center;
+		LL_TIM_OC_Init(instance, LL_TIM_CHANNEL_CH6, &oc_init);
+		LL_TIM_SetTriggerOutput2(instance, LL_TIM_TRGO2_OC6);
+	}
+	else
+	{
+		LL_TIM_SetTriggerOutput2(instance, LL_TIM_TRGO2_UPDATE);
+	}
 
 	// restart all the timers of the driver
 	stm32_resume(driver_params);
@@ -191,27 +246,39 @@ void* Phoque_CurrentSense::ConfigureADC(const void* driver_params, const int pin
 
 	HAL_Init();
 	GPIO_Init();
-	DMA_Init(); 
+	DMA_InitClock(); 
+	OPAMP_Init();
 	hadc1.Init.NbrOfConversion = 0;
 	hadc2.Init.NbrOfConversion = 0;
 	int adc1_len = ADC1_Init(&hadc1);
 	int adc2_len = ADC2_Init(&hadc2);
-	adc1_buffer = new uint16_t[adc1_len];
-	adc2_buffer = new uint16_t[adc2_len];
+	//allocate single buffer for faster cache access
+	adc1_buffer = new uint16_t[adc1_len+adc2_len];
+	adc2_buffer = &adc1_buffer[adc1_len];
 
 	HAL_ADCEx_Calibration_Start(&hadc1,ADC_SINGLE_ENDED);
 	HAL_ADCEx_Calibration_Start(&hadc2,ADC_SINGLE_ENDED);
 
-	DMA1_Init(&hadc1, &hdma_adc1, DMA1_Channel1, DMA_REQUEST_ADC1);
-	DMA1_Init(&hadc2, &hdma_adc2, DMA2_Channel1, DMA_REQUEST_ADC2);
+	DMA_Init(&hadc1, &hdma_adc1, DMA1_Channel1, DMA_REQUEST_ADC1);
+	DMA_Init(&hadc2, &hdma_adc2, DMA2_Channel1, DMA_REQUEST_ADC2);
+
+	#ifdef PHOQUE_DEBUG_SAMPLING
+	//End of Sample
+	LL_ADC_EnableIT_EOSMP(ADC1);
+	LL_ADC_EnableIT_EOSMP(ADC2);
+
+	//End of conversion sequence
+	LL_ADC_EnableIT_EOS(ADC1);
+	LL_ADC_EnableIT_EOS(ADC2);
+	#endif
 
 	if (HAL_ADC_Start_DMA(&hadc1, (uint32_t*)adc1_buffer, adc1_len) != HAL_OK)
 	{
-		SIMPLEFOC_DEBUG("ADC1 DMA read init failed");
+		SIMPLEFOC_DEBUG(PHOQUE_CS_DEBUG "ADC1 DMA read init failed");
 	}
 	if (HAL_ADC_Start_DMA(&hadc2, (uint32_t*)adc2_buffer, adc2_len) != HAL_OK)
 	{
-		SIMPLEFOC_DEBUG("ADC2 DMA read init failed");
+		SIMPLEFOC_DEBUG(PHOQUE_CS_DEBUG "ADC2 DMA read init failed");
 	}
 	
 	Stm32CurrentSenseParams* params = new Stm32CurrentSenseParams {
@@ -223,23 +290,24 @@ void* Phoque_CurrentSense::ConfigureADC(const void* driver_params, const int pin
 	return params;
 }
 
-float Phoque_CurrentSense::readMillivolt(const int pin)
+inline float Phoque_CurrentSense::readMillivolt(const int pin) const
 {
 	return readRaw(pin) * ((Stm32CurrentSenseParams*)params)->adc_voltage_conv;
 }
 
 PhaseCurrent_s Phoque_CurrentSense::getPhaseCurrents(){
+	#define compute_current(pin, offset, gain, index) (readMillivolt(pin) - offset)*gain
     PhaseCurrent_s current;
-    current.a = (readMillivolt(pinA) - offset_ia)*gain_a; // amps
-    current.b = (readMillivolt(pinB) - offset_ib)*gain_b; // amps
-    current.c = (readMillivolt(pinC) - offset_ic)*gain_c; // amps
+    current.a = compute_current(pinA, offset_ia, gain_a, 0);
+    current.b = compute_current(pinB, offset_ib, gain_b, 1);
+	current.c = compute_current(pinC, offset_ic, gain_c, 2);
     return current;
 }
 
 int Phoque_CurrentSense::init()
 {
 	if (driver==nullptr) {
-		SIMPLEFOC_DEBUG("CUR: Driver not linked!");
+		SIMPLEFOC_DEBUG(PHOQUE_CS_DEBUG "Driver not linked!");
 		return 0;
 	}
 	if (initialized)
@@ -259,7 +327,8 @@ int Phoque_CurrentSense::init()
 	if(driver_type==DriverType::BLDC)
 	{
 		BLDCDriver* driver_bldc = static_cast<BLDCDriver*>(driver);
-		driver_bldc->setPwm(driver->voltage_limit/2, driver->voltage_limit/2, driver->voltage_limit/2);
+		const float voltage_target = driver->voltage_limit/2;
+		driver_bldc->setPwm(voltage_target, voltage_target, voltage_target);
 	}
 		
 	// calibrate zero offsets
@@ -284,7 +353,7 @@ void Phoque_CurrentSense::calibrateOffsets(){
     for (int i = 0; i < calibration_rounds; i++) {
 		const uint16_t curru(readRaw(pinA)), currv(readRaw(pinB)), currw(readRaw(pinC));
 		//check if new data
-		if (curru >= 0x1000 || currv >= 0x1000 || currw >= 0x1000)
+		if (curru > adc_resolution || currv > adc_resolution || currw > adc_resolution)
 		{
 			//no new data: this iteration didn't happen
 			i--;
@@ -297,7 +366,7 @@ void Phoque_CurrentSense::calibrateOffsets(){
 			continue;
 		}
 		//invalidate current data
-		adc2_buffer[0] = adc2_buffer[1] = adc1_buffer[0] = 0xffff;
+		clear_currents();
         accA += curru;
         accB += currv;
         accC += currw;
@@ -307,15 +376,81 @@ void Phoque_CurrentSense::calibrateOffsets(){
     offset_ia = accA * ((Stm32CurrentSenseParams*)params)->adc_voltage_conv / calibration_rounds;
     offset_ib = accB * ((Stm32CurrentSenseParams*)params)->adc_voltage_conv / calibration_rounds;
     offset_ic = accC * ((Stm32CurrentSenseParams*)params)->adc_voltage_conv / calibration_rounds;
-	SimpleFOCDebug::printf("PHOQUE-CS: Calibrated centers at %f, %f, %f\r\n", offset_ia, offset_ib, offset_ic);
+	SimpleFOCDebug::printf(PHOQUE_CS_DEBUG "Calibrated centers at %f, %f, %f (gains %f %f %f)\r\n", offset_ia, offset_ib, offset_ic, gain_a, gain_b, gain_c);
 }
 
 int Phoque_CurrentSense::driverAlign(float align_voltage, bool modulation_centered)
 {
 	_UNUSED(align_voltage);
 	_UNUSED(modulation_centered);
+	#if 1
 	return 1;
+	#else
+	return CurrentSense::driverAlign(align_voltage, modulation_centered);
+	#endif
 }
+
+#if defined(NTC_B_CONSTANT) && defined(NTC_T0)
+#include <array>
+
+#ifndef TEMP_LUT_SIZE
+	#define TEMP_LUT_SIZE 7
+#endif
+#ifndef TEMP_STEP
+	#define TEMP_STEP 1 //get every n degrees
+#endif
+#ifndef TEMP_INDEX_ZERO
+	#define TEMP_INDEX_ZERO 20 //start at 20C
+#endif
+
+uint16_t temperature_to_adc_reading(float temp_C)
+{
+	//R0 : resistance at T0
+	//R1 : resistance value of the other side of the voltage divider
+	//B = ln(R/R0)/(1/T-1/T0) -> R/R0 = exp(B*(1/T-1/T0)) -> R = exp(B*(1/T-1/T0))*R0
+	//NTC_DIVIDER_BALANCE = R0/R1
+	//V = R/(R+R1)*3.3
+	//adc_reading = V/3.3*adc_resolution = R/(R+R1)*adc_resolution = R/(R1(1+R/R1)) * adc_resolution
+	float temp_K = temp_C + 273.15f;
+	float R_over_R0 = expf(NTC_B_CONSTANT * (1/temp_K-1/NTC_T0));
+	#ifdef NTC_DIVIDER_BALANCE
+	float R_over_R1 = R_over_R0 / NTC_DIVIDER_BALANCE;
+	#else
+	float R_over_R1 = R_over_R0;
+	#endif
+	float adc_reading = R_over_R1/(1+R_over_R1) *adc_resolution;
+	return adc_reading;
+}
+
+template <class T, size_t N>
+std::array<T, N> fill_temperature_lut() {
+    std::array<T, N> a;
+    for (size_t i = 0; i < N; ++i)
+        a[i] = temperature_to_adc_reading((i-1) * TEMP_STEP + TEMP_INDEX_ZERO);
+    return a;
+}
+
+const auto temperature_lut = fill_temperature_lut<uint16_t, 1<<TEMP_LUT_SIZE>();
+
+int Phoque_CurrentSense::get_temperature(uint16_t adc_value)
+{
+	uint8_t index = 0;
+	for (int8_t i = TEMP_LUT_SIZE-1; i >= 0; i--)
+	{
+		uint8_t n_index = index | 1<<i;
+		if (temperature_lut[n_index] > adc_value)
+		{
+			index = n_index;
+		}
+	}
+	return index * TEMP_STEP + TEMP_INDEX_ZERO;
+}
+
+int Phoque_CurrentSense::read_temperature() const
+{
+	return get_temperature(readRaw(A_TEMPERATURE));
+}
+#endif
 
 #ifdef DMA_USE_INTERRUPT
 extern "C" {

--- a/src/current_sense/phoque/Phoque_CurrentSense.cpp
+++ b/src/current_sense/phoque/Phoque_CurrentSense.cpp
@@ -54,13 +54,15 @@ void Phoque_CurrentSense::DMA_Init()
 	__HAL_RCC_DMA1_CLK_ENABLE();
 	__HAL_RCC_DMA2_CLK_ENABLE();
 
+	#ifdef DMA_USE_INTERRUPT
 	/* DMA interrupt init */
 	/* DMA1_Channel1_IRQn interrupt configuration */
 	HAL_NVIC_SetPriority(DMA1_Channel1_IRQn, 0, 0);
 	HAL_NVIC_EnableIRQ(DMA1_Channel1_IRQn);
 	/* DMA1_Channel2_IRQn interrupt configuration */
-	HAL_NVIC_SetPriority(DMA1_Channel2_IRQn, 0, 0);
-	HAL_NVIC_EnableIRQ(DMA1_Channel2_IRQn);
+	HAL_NVIC_SetPriority(DMA2_Channel1_IRQn, 0, 0);
+	HAL_NVIC_EnableIRQ(DMA2_Channel1_IRQn);
+	#endif
 
 	// Enable external clock for ADC
 	RCC_PeriphCLKInitTypeDef PeriphClkInit;
@@ -171,7 +173,6 @@ void* Phoque_CurrentSense::SyncLowSide(void* _driver_params, void* _cs_params)
 		SIMPLEFOC_DEBUG("STM32-CS: timer has no repetition counter, ADC interrupt not supported for this Phoque");
 		return SIMPLEFOC_CURRENT_SENSE_INIT_FAILED;
 	}
-
 	// set the trigger output event
 	LL_TIM_SetTriggerOutput(cs_params->timer_handle->Instance, LL_TIM_TRGO_UPDATE);
 
@@ -202,7 +203,7 @@ void* Phoque_CurrentSense::ConfigureADC(const void* driver_params, const int pin
 	HAL_ADCEx_Calibration_Start(&hadc2,ADC_SINGLE_ENDED);
 
 	DMA1_Init(&hadc1, &hdma_adc1, DMA1_Channel1, DMA_REQUEST_ADC1);
-	DMA1_Init(&hadc2, &hdma_adc2, DMA1_Channel2, DMA_REQUEST_ADC2);
+	DMA1_Init(&hadc2, &hdma_adc2, DMA2_Channel1, DMA_REQUEST_ADC2);
 
 	if (HAL_ADC_Start_DMA(&hadc1, (uint32_t*)adc1_buffer, adc1_len) != HAL_OK)
 	{
@@ -276,6 +277,7 @@ int Phoque_CurrentSense::init()
 void Phoque_CurrentSense::calibrateOffsets(){    
     const int calibration_rounds = 2000;
 
+
     // find adc offset = zero current voltage
 	uint32_t accA = 0, accB = 0, accC = 0;
     // read the adc voltage 1000 times ( arbitrary number )
@@ -287,7 +289,11 @@ void Phoque_CurrentSense::calibrateOffsets(){
 			//no new data: this iteration didn't happen
 			i--;
 			//wait for interrupt (dma irq should do it)
+			#ifdef DMA_USE_INTERRUPT
 			__WFI();
+			#else
+			delayMicroseconds(100);
+			#endif
 			continue;
 		}
 		//invalidate current data
@@ -296,10 +302,12 @@ void Phoque_CurrentSense::calibrateOffsets(){
         accB += currv;
         accC += currw;
     }
+	
     // calculate the mean offsets
     offset_ia = accA * ((Stm32CurrentSenseParams*)params)->adc_voltage_conv / calibration_rounds;
     offset_ib = accB * ((Stm32CurrentSenseParams*)params)->adc_voltage_conv / calibration_rounds;
     offset_ic = accC * ((Stm32CurrentSenseParams*)params)->adc_voltage_conv / calibration_rounds;
+	SimpleFOCDebug::printf("PHOQUE-CS: Calibrated centers at %f, %f, %f\r\n", offset_ia, offset_ib, offset_ic);
 }
 
 int Phoque_CurrentSense::driverAlign(float align_voltage, bool modulation_centered)
@@ -309,14 +317,16 @@ int Phoque_CurrentSense::driverAlign(float align_voltage, bool modulation_center
 	return 1;
 }
 
+#ifdef DMA_USE_INTERRUPT
 extern "C" {
 void DMA1_Channel1_IRQHandler(void) {
 	HAL_DMA_IRQHandler(&hdma_adc1);
 }
 
-void DMA1_Channel2_IRQHandler(void) {
+void DMA2_Channel1_IRQHandler(void) {
 	HAL_DMA_IRQHandler(&hdma_adc2);
 }
 }
+#endif
 
 #endif

--- a/src/current_sense/phoque/Phoque_CurrentSense.hpp
+++ b/src/current_sense/phoque/Phoque_CurrentSense.hpp
@@ -7,8 +7,8 @@
 class Phoque_CurrentSense : public CurrentSense
 {
 protected:
-	volatile uint16_t *adc1_buffer = nullptr;
-	volatile uint16_t *adc2_buffer = nullptr;
+	uint16_t *adc1_buffer = nullptr;
+	uint16_t *adc2_buffer = nullptr;
 	bool read_bemf;
 public:
 	Phoque_CurrentSense(float shunt_resistor, float gain, bool read_bemf=false);
@@ -17,24 +17,39 @@ public:
 
 	virtual int init() override;
 	virtual PhaseCurrent_s getPhaseCurrents() override;
-	virtual int driverAlign(float align_voltage, bool modulation_centered = false) override;
+	int driverAlign(float align_voltage, bool modulation_centered = false) final;
 
-	virtual float readMillivolt(const int pin);
-	virtual uint16_t readRaw(const int pin) = 0;
+	virtual float readMillivolt(const int pin) const;
+	virtual uint16_t readRaw(const int pin) const = 0 ;
+	#if defined(NTC_B_CONSTANT) && defined(NTC_T0)
+	static int get_temperature(uint16_t adc_value);
+	int read_temperature() const;
+	#endif
 
 protected:
-	void GPIO_Init();
-	void DMA_Init();
+	virtual void GPIO_Init();
+	virtual void DMA_InitClock();
 	virtual void OPAMP_Init();
+
+	//get duration of conversion in ADC clock cycles
+	//sample ticks is the number of clock cycles to sample for, rounded down (for ADC_SAMPLETIME_6CYCLES_5, it's 6)
+	int get_conversion_duration(int sample_ticks) const;
+	//duration of the sampling for adc1, in ADC clock cycles
+	virtual int get_adc1_important_duration() = 0;
+	//duration of the sampling for adc2, in ADC clock cycles
+	virtual int get_adc2_important_duration() = 0;
+
 	//Configure ADC1, child classes should configure each rank to sample, return number of samples
 	virtual int ADC1_Init(ADC_HandleTypeDef* hadc1);
 	//Configure ADC2, child classes should configure each rank to sample, return number of samples
 	virtual int ADC2_Init(ADC_HandleTypeDef* hadc2);
-	virtual void DMA1_Init(ADC_HandleTypeDef *hadc, DMA_HandleTypeDef *hdma_adc, DMA_Channel_TypeDef* channel, uint32_t request);
+	virtual void DMA_Init(ADC_HandleTypeDef *hadc, DMA_HandleTypeDef *hdma_adc, DMA_Channel_TypeDef* channel, uint32_t request);
 	virtual void* SyncLowSide(void* driver_params, void* cs_params);
 	virtual void* ConfigureADC(const void* driver_params, const int pinA, const int pinB, const int pinC);
 
+	virtual void clear_currents() = 0;
 	virtual void calibrateOffsets();
+
 };
 
 #endif

--- a/src/current_sense/phoque1/Phoque1_CurrentSense.cpp
+++ b/src/current_sense/phoque1/Phoque1_CurrentSense.cpp
@@ -28,12 +28,13 @@ Phoque1_CurrentSense::~Phoque1_CurrentSense()
 {
 }
 
-void Phoque1_CurrentSense::Opamp_Init()
+void Phoque1_CurrentSense::OPAMP_Init()
 {
 	GPIO_InitTypeDef GPIO_InitStruct = {0};
-	GPIO_InitStruct.Pin = GPIO_PIN_1|GPIO_PIN_3 | GPIO_PIN_5|GPIO_PIN_7; //Opamp 1 | Opamp 2
 	GPIO_InitStruct.Mode = GPIO_MODE_ANALOG;
 	GPIO_InitStruct.Pull = GPIO_NOPULL;
+
+	GPIO_InitStruct.Pin = GPIO_PIN_1|GPIO_PIN_3 | GPIO_PIN_5|GPIO_PIN_7; //Opamp 1 | Opamp 2
 	HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
 
 	GPIO_InitStruct.Pin = GPIO_PIN_0|GPIO_PIN_2; // Opamp 3
@@ -47,14 +48,16 @@ void Phoque1_CurrentSense::Opamp_Init()
 	{
 		auto hopamp = opamp_handles[i];
 		hopamp->Instance = opamp_instances[i];
-		hopamp->Init.PowerMode = OPAMP_POWERMODE_HIGHSPEED;
-		hopamp->Init.Mode = OPAMP_PGA_MODE;
-		hopamp->Init.NonInvertingInput = OPAMP_NONINVERTINGINPUT_IO0;
-		hopamp->Init.InternalOutput = ENABLE;
-		hopamp->Init.TimerControlledMuxmode = OPAMP_TIMERCONTROLLEDMUXMODE_DISABLE;
-		hopamp->Init.PgaConnect = OPAMP_PGA_CONNECT_INVERTINGINPUT_IO0_BIAS;
-		hopamp->Init.PgaGain = OPAMP_PGA_GAIN_16_OR_MINUS_15;
-		hopamp->Init.UserTrimming = OPAMP_TRIMMING_FACTORY;
+		hopamp->Init = {
+			.PowerMode = OPAMP_POWERMODE_HIGHSPEED,
+			.Mode = OPAMP_PGA_MODE,
+			.NonInvertingInput = OPAMP_NONINVERTINGINPUT_IO0,
+			.InternalOutput = ENABLE,
+			.TimerControlledMuxmode = OPAMP_TIMERCONTROLLEDMUXMODE_DISABLE,
+			.PgaConnect = OPAMP_PGA_CONNECT_INVERTINGINPUT_IO0_BIAS,
+			.PgaGain = OPAMP_PGA_GAIN_16_OR_MINUS_15,
+			.UserTrimming = OPAMP_TRIMMING_FACTORY,
+		};
 		if (HAL_OPAMP_Init(hopamp) != HAL_OK)
 		{
 			SIMPLEFOC_DEBUG("HAL_OPAMP_Init failed!");
@@ -63,6 +66,24 @@ void Phoque1_CurrentSense::Opamp_Init()
 	}
 }
 
+#define SAMPLETIME_BULB ADC_SAMPLETIME_640CYCLES_5
+#define BULB_CYCLES 640
+#define SAMPLETIME_IMPORTANT ADC_SAMPLETIME_6CYCLES_5
+#define IMPORTANT_CYCLES 6
+#define SAMPLETIME_PERIPHERAL ADC_SAMPLETIME_47CYCLES_5
+//Start sampling for a long time for the first sample, but sample so that all of the important conversions are centered around update
+int Phoque1_CurrentSense::get_adc1_important_duration()
+{
+	return (read_bemf ? 2:0) * get_conversion_duration(IMPORTANT_CYCLES) + BULB_CYCLES*2;
+}
+
+int Phoque1_CurrentSense::get_adc2_important_duration()
+{
+	return (read_bemf ? 2:1) * get_conversion_duration(IMPORTANT_CYCLES) + BULB_CYCLES*2;
+}
+
+const char *ADC_ConfigFail = "HAL_ADC_ConfigChannel %d failed!\r\n";
+
 int Phoque1_CurrentSense::ADC1_Init(ADC_HandleTypeDef* hadc1)
 {
 	ADC_ChannelConfTypeDef sConfig = {0};
@@ -70,17 +91,17 @@ int Phoque1_CurrentSense::ADC1_Init(ADC_HandleTypeDef* hadc1)
 	sConfig.OffsetNumber = ADC_OFFSET_NONE;
 	sConfig.Offset = 0;
 
-	hadc1->Init.NbrOfConversion += 3 + read_bemf * 2;
+	hadc1->Init.NbrOfConversion += read_bemf ? 5 : 3;
 	Phoque_CurrentSense::ADC1_Init(hadc1);
 
 	/** Configure Regular Channel (Opamp 1 / phase W current)
 	*/
 	sConfig.Channel = ADC_CHANNEL_13;  // OP1_OUT is ADC1_IN13 for internal channel
 	sConfig.Rank = ADC_REGULAR_RANK_1;
-	sConfig.SamplingTime = ADC_SAMPLETIME_6CYCLES_5;
+	sConfig.SamplingTime = SAMPLETIME_BULB;
 	if (HAL_ADC_ConfigChannel(hadc1, &sConfig) != HAL_OK)
 	{
-		SIMPLEFOC_DEBUG("HAL_ADC_ConfigChannel failed!");
+		SimpleFOCDebug::printf(ADC_ConfigFail, 1);
 	}
 
 	if(read_bemf)
@@ -89,22 +110,23 @@ int Phoque1_CurrentSense::ADC1_Init(ADC_HandleTypeDef* hadc1)
 		*/
 		sConfig.Channel = _getADCChannel(analogInputToPinName(A_BEMFU), ADC1);
 		sConfig.Rank = ADC_REGULAR_RANK_2;
-		sConfig.SamplingTime = ADC_SAMPLETIME_6CYCLES_5;
+		sConfig.SamplingTime = SAMPLETIME_IMPORTANT;
 		if (HAL_ADC_ConfigChannel(hadc1, &sConfig) != HAL_OK)
 		{
-			SIMPLEFOC_DEBUG("HAL_ADC_ConfigChannel failed!");
+			SimpleFOCDebug::printf(ADC_ConfigFail, 2);
 		}
 
 		/* Configure Regular Channel (PC4 / BEMFV / Phase V)
 		*/
 		sConfig.Channel = _getADCChannel(analogInputToPinName(A_BEMFV), ADC1);
 		sConfig.Rank = ADC_REGULAR_RANK_3;
-		sConfig.SamplingTime = ADC_SAMPLETIME_6CYCLES_5;
+		sConfig.SamplingTime = SAMPLETIME_IMPORTANT;
 		if (HAL_ADC_ConfigChannel(hadc1, &sConfig) != HAL_OK)
 		{
-			SIMPLEFOC_DEBUG("HAL_ADC_ConfigChannel failed!");
+			SimpleFOCDebug::printf(ADC_ConfigFail, 3);
 		}
 	}
+	
 
 	//******************************************************************
 	// Aux analog readings
@@ -112,20 +134,20 @@ int Phoque1_CurrentSense::ADC1_Init(ADC_HandleTypeDef* hadc1)
 	*/
 	sConfig.Channel = _getADCChannel(analogInputToPinName(A_VBUS), ADC1);
 	sConfig.Rank = read_bemf ? ADC_REGULAR_RANK_4 : ADC_REGULAR_RANK_2;
-	sConfig.SamplingTime = ADC_SAMPLETIME_47CYCLES_5;
+	sConfig.SamplingTime = SAMPLETIME_PERIPHERAL;
 	if (HAL_ADC_ConfigChannel(hadc1, &sConfig) != HAL_OK)
 	{
-		SIMPLEFOC_DEBUG("HAL_ADC_ConfigChannel failed!");
+		SimpleFOCDebug::printf(ADC_ConfigFail, read_bemf ? 4:2);
 	}
 
 	/** Configure Regular Channel (PC0, Potentiometer)
 	*/
 	sConfig.Channel = _getADCChannel(analogInputToPinName(A_POTENTIOMETER), ADC1);
 	sConfig.Rank = read_bemf ? ADC_REGULAR_RANK_5 : ADC_REGULAR_RANK_3;
-	sConfig.SamplingTime = ADC_SAMPLETIME_47CYCLES_5;
+	sConfig.SamplingTime = SAMPLETIME_PERIPHERAL;
 	if (HAL_ADC_ConfigChannel(hadc1, &sConfig) != HAL_OK)
 	{
-		SIMPLEFOC_DEBUG("HAL_ADC_ConfigChannel failed!");
+		SimpleFOCDebug::printf(ADC_ConfigFail, read_bemf ? 5:3);
 	}
 	return hadc1->Init.NbrOfConversion;
 }
@@ -137,26 +159,26 @@ int Phoque1_CurrentSense::ADC2_Init(ADC_HandleTypeDef* hadc2)
 	sConfig.OffsetNumber = ADC_OFFSET_NONE;
 	sConfig.Offset = 0;
 
-	hadc2->Init.NbrOfConversion += 3 + read_bemf;
+	hadc2->Init.NbrOfConversion += read_bemf ? 4 : 3;
 	Phoque_CurrentSense::ADC2_Init(hadc2);
 
 	/** Configure Regular Channel (Opamp 2 / phase U current)
 	*/
 	sConfig.Channel = ADC_CHANNEL_16;  // OP2_OUT is ADC2_IN16 for internal channel
 	sConfig.Rank = ADC_REGULAR_RANK_1;
-	sConfig.SamplingTime = ADC_SAMPLETIME_6CYCLES_5;
+	sConfig.SamplingTime = SAMPLETIME_BULB;
 	if (HAL_ADC_ConfigChannel(hadc2, &sConfig) != HAL_OK)
 	{
-		SIMPLEFOC_DEBUG("HAL_ADC_ConfigChannel failed!");
+		SimpleFOCDebug::printf(ADC_ConfigFail, 1);
 	}
 	/** Configure Regular Channel (Opamp 3 / phase V current)
 	*/
 	sConfig.Channel = ADC_CHANNEL_18;     // OP3_OUT is ADC2_IN18 for internal channel
 	sConfig.Rank = ADC_REGULAR_RANK_2;
-	sConfig.SamplingTime = ADC_SAMPLETIME_6CYCLES_5;
+	sConfig.SamplingTime = SAMPLETIME_IMPORTANT;
 	if (HAL_ADC_ConfigChannel(hadc2, &sConfig) != HAL_OK)
 	{
-		SIMPLEFOC_DEBUG("HAL_ADC_ConfigChannel failed!");
+		SimpleFOCDebug::printf(ADC_ConfigFail, 2);
 	}
 
 	if(read_bemf)
@@ -165,26 +187,27 @@ int Phoque1_CurrentSense::ADC2_Init(ADC_HandleTypeDef* hadc2)
 		*/
 		sConfig.Channel = _getADCChannel(analogInputToPinName(A_BEMFW), ADC2);
 		sConfig.Rank = ADC_REGULAR_RANK_3;
-		sConfig.SamplingTime = ADC_SAMPLETIME_6CYCLES_5;
+		sConfig.SamplingTime = SAMPLETIME_IMPORTANT;
 		if (HAL_ADC_ConfigChannel(hadc2, &sConfig) != HAL_OK)
 		{
-			SIMPLEFOC_DEBUG("HAL_ADC_ConfigChannel failed!");
+			SimpleFOCDebug::printf(ADC_ConfigFail, 3);
 		}
 	}
+	
 
 	/** Configure Regular Channel (PF1 / Mosfet temperature)
 	*/
 	sConfig.Channel = _getADCChannel(analogInputToPinName(A_TEMPERATURE), ADC2);
 	sConfig.Rank = read_bemf ? ADC_REGULAR_RANK_4 : ADC_REGULAR_RANK_3;
-	sConfig.SamplingTime = ADC_SAMPLETIME_47CYCLES_5;
+	sConfig.SamplingTime = SAMPLETIME_PERIPHERAL;
 	if (HAL_ADC_ConfigChannel(hadc2, &sConfig) != HAL_OK)
 	{
-		SIMPLEFOC_DEBUG("HAL_ADC_ConfigChannel failed!");
+		SimpleFOCDebug::printf(ADC_ConfigFail, read_bemf ? 4:3);
 	}
 	return hadc2->Init.NbrOfConversion;
 }
 
-uint16_t Phoque1_CurrentSense::readRaw(const int pin)
+uint16_t Phoque1_CurrentSense::readRaw(const int pin) const
 {
     switch (pin)
 	{
@@ -205,15 +228,22 @@ uint16_t Phoque1_CurrentSense::readRaw(const int pin)
 	case A_BEMFW:
 		return adc2_buffer[2];
 
-	case A_POTENTIOMETER:
-		return adc1_buffer[2+read_bemf*2];
-	case A_TEMPERATURE:
-		return adc2_buffer[2+read_bemf];
 	case A_VBUS:
-		return adc1_buffer[1+read_bemf*2];
+		return adc1_buffer[read_bemf ? 3:1];
+	case A_POTENTIOMETER:
+		return adc1_buffer[read_bemf ? 4:2];
+	case A_TEMPERATURE:
+		return adc2_buffer[read_bemf ? 3:2];
 	default:
 		return 0;
 	}
+}
+
+inline void Phoque1_CurrentSense::clear_currents()
+{
+	adc1_buffer[0] = UINT16_MAX;
+	adc2_buffer[0] = UINT16_MAX;
+	adc2_buffer[1] = UINT16_MAX;
 }
 
 #endif

--- a/src/current_sense/phoque1/Phoque1_CurrentSense.cpp
+++ b/src/current_sense/phoque1/Phoque1_CurrentSense.cpp
@@ -1,0 +1,219 @@
+#if defined(ARDUINO_PHOQUE1)
+
+#include "Phoque1_CurrentSense.hpp"
+#include "communication/SimpleFOCDebug.h"
+#include "current_sense/hardware_specific/stm32/stm32_adc_utils.h"
+
+static OPAMP_HandleTypeDef hopamp1;
+static OPAMP_HandleTypeDef hopamp2;
+static OPAMP_HandleTypeDef hopamp3;
+
+Phoque1_CurrentSense::Phoque1_CurrentSense(float _shunt_resistor, float _gain, bool _read_bemf)
+	:Phoque_CurrentSense(_shunt_resistor, _gain, _read_bemf)
+{
+	pinA = A_CURRU_H;
+	pinB = A_CURRV_H;
+	pinC = A_CURRW_H;
+}
+
+Phoque1_CurrentSense::Phoque1_CurrentSense(float mVpA, bool _read_bemf)
+	:Phoque_CurrentSense(mVpA, _read_bemf)
+{
+	pinA = A_CURRU_H;
+	pinB = A_CURRV_H;
+	pinC = A_CURRW_H;
+}
+
+Phoque1_CurrentSense::~Phoque1_CurrentSense()
+{
+}
+
+void Phoque1_CurrentSense::Opamp_Init()
+{
+	GPIO_InitTypeDef GPIO_InitStruct = {0};
+	GPIO_InitStruct.Pin = GPIO_PIN_1|GPIO_PIN_3 | GPIO_PIN_5|GPIO_PIN_7; //Opamp 1 | Opamp 2
+	GPIO_InitStruct.Mode = GPIO_MODE_ANALOG;
+	GPIO_InitStruct.Pull = GPIO_NOPULL;
+	HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
+
+	GPIO_InitStruct.Pin = GPIO_PIN_0|GPIO_PIN_2; // Opamp 3
+	HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
+
+	OPAMP_HandleTypeDef *opamp_handles[] = {&hopamp1, &hopamp2, &hopamp3};
+	OPAMP_TypeDef *opamp_instances[] = {OPAMP1, OPAMP2, OPAMP3};
+	static_assert(sizeof(opamp_handles)/sizeof(opamp_handles[0]) == sizeof(opamp_instances)/sizeof(opamp_instances[0]));
+
+	for (size_t i = 0; i < sizeof(opamp_handles)/sizeof(opamp_handles[0]); i++)
+	{
+		auto hopamp = opamp_handles[i];
+		hopamp->Instance = opamp_instances[i];
+		hopamp->Init.PowerMode = OPAMP_POWERMODE_HIGHSPEED;
+		hopamp->Init.Mode = OPAMP_PGA_MODE;
+		hopamp->Init.NonInvertingInput = OPAMP_NONINVERTINGINPUT_IO0;
+		hopamp->Init.InternalOutput = ENABLE;
+		hopamp->Init.TimerControlledMuxmode = OPAMP_TIMERCONTROLLEDMUXMODE_DISABLE;
+		hopamp->Init.PgaConnect = OPAMP_PGA_CONNECT_INVERTINGINPUT_IO0_BIAS;
+		hopamp->Init.PgaGain = OPAMP_PGA_GAIN_16_OR_MINUS_15;
+		hopamp->Init.UserTrimming = OPAMP_TRIMMING_FACTORY;
+		if (HAL_OPAMP_Init(hopamp) != HAL_OK)
+		{
+			SIMPLEFOC_DEBUG("HAL_OPAMP_Init failed!");
+		}
+		HAL_OPAMP_Start(hopamp);
+	}
+}
+
+int Phoque1_CurrentSense::ADC1_Init(ADC_HandleTypeDef* hadc1)
+{
+	ADC_ChannelConfTypeDef sConfig = {0};
+	sConfig.SingleDiff = ADC_SINGLE_ENDED;
+	sConfig.OffsetNumber = ADC_OFFSET_NONE;
+	sConfig.Offset = 0;
+
+	hadc1->Init.NbrOfConversion += 3 + read_bemf * 2;
+	Phoque_CurrentSense::ADC1_Init(hadc1);
+
+	/** Configure Regular Channel (Opamp 1 / phase W current)
+	*/
+	sConfig.Channel = ADC_CHANNEL_13;  // OP1_OUT is ADC1_IN13 for internal channel
+	sConfig.Rank = ADC_REGULAR_RANK_1;
+	sConfig.SamplingTime = ADC_SAMPLETIME_6CYCLES_5;
+	if (HAL_ADC_ConfigChannel(hadc1, &sConfig) != HAL_OK)
+	{
+		SIMPLEFOC_DEBUG("HAL_ADC_ConfigChannel failed!");
+	}
+
+	if(read_bemf)
+	{
+		/* Configure Regular Channel (PA0 / BEMFU / Phase U)
+		*/
+		sConfig.Channel = _getADCChannel(analogInputToPinName(A_BEMFU), ADC1);
+		sConfig.Rank = ADC_REGULAR_RANK_2;
+		sConfig.SamplingTime = ADC_SAMPLETIME_6CYCLES_5;
+		if (HAL_ADC_ConfigChannel(hadc1, &sConfig) != HAL_OK)
+		{
+			SIMPLEFOC_DEBUG("HAL_ADC_ConfigChannel failed!");
+		}
+
+		/* Configure Regular Channel (PC4 / BEMFV / Phase V)
+		*/
+		sConfig.Channel = _getADCChannel(analogInputToPinName(A_BEMFV), ADC1);
+		sConfig.Rank = ADC_REGULAR_RANK_3;
+		sConfig.SamplingTime = ADC_SAMPLETIME_6CYCLES_5;
+		if (HAL_ADC_ConfigChannel(hadc1, &sConfig) != HAL_OK)
+		{
+			SIMPLEFOC_DEBUG("HAL_ADC_ConfigChannel failed!");
+		}
+	}
+
+	//******************************************************************
+	// Aux analog readings
+	/* Configure Regular Channel (PC1, supply voltage)
+	*/
+	sConfig.Channel = _getADCChannel(analogInputToPinName(A_VBUS), ADC1);
+	sConfig.Rank = read_bemf ? ADC_REGULAR_RANK_4 : ADC_REGULAR_RANK_2;
+	sConfig.SamplingTime = ADC_SAMPLETIME_47CYCLES_5;
+	if (HAL_ADC_ConfigChannel(hadc1, &sConfig) != HAL_OK)
+	{
+		SIMPLEFOC_DEBUG("HAL_ADC_ConfigChannel failed!");
+	}
+
+	/** Configure Regular Channel (PC0, Potentiometer)
+	*/
+	sConfig.Channel = _getADCChannel(analogInputToPinName(A_POTENTIOMETER), ADC1);
+	sConfig.Rank = read_bemf ? ADC_REGULAR_RANK_5 : ADC_REGULAR_RANK_3;
+	sConfig.SamplingTime = ADC_SAMPLETIME_47CYCLES_5;
+	if (HAL_ADC_ConfigChannel(hadc1, &sConfig) != HAL_OK)
+	{
+		SIMPLEFOC_DEBUG("HAL_ADC_ConfigChannel failed!");
+	}
+	return hadc1->Init.NbrOfConversion;
+}
+
+int Phoque1_CurrentSense::ADC2_Init(ADC_HandleTypeDef* hadc2)
+{
+	ADC_ChannelConfTypeDef sConfig = {0};
+	sConfig.SingleDiff = ADC_SINGLE_ENDED;
+	sConfig.OffsetNumber = ADC_OFFSET_NONE;
+	sConfig.Offset = 0;
+
+	hadc2->Init.NbrOfConversion += 3 + read_bemf;
+	Phoque_CurrentSense::ADC2_Init(hadc2);
+
+	/** Configure Regular Channel (Opamp 2 / phase U current)
+	*/
+	sConfig.Channel = ADC_CHANNEL_16;  // OP2_OUT is ADC2_IN16 for internal channel
+	sConfig.Rank = ADC_REGULAR_RANK_1;
+	sConfig.SamplingTime = ADC_SAMPLETIME_6CYCLES_5;
+	if (HAL_ADC_ConfigChannel(hadc2, &sConfig) != HAL_OK)
+	{
+		SIMPLEFOC_DEBUG("HAL_ADC_ConfigChannel failed!");
+	}
+	/** Configure Regular Channel (Opamp 3 / phase V current)
+	*/
+	sConfig.Channel = ADC_CHANNEL_18;     // OP3_OUT is ADC2_IN18 for internal channel
+	sConfig.Rank = ADC_REGULAR_RANK_2;
+	sConfig.SamplingTime = ADC_SAMPLETIME_6CYCLES_5;
+	if (HAL_ADC_ConfigChannel(hadc2, &sConfig) != HAL_OK)
+	{
+		SIMPLEFOC_DEBUG("HAL_ADC_ConfigChannel failed!");
+	}
+
+	if(read_bemf)
+	{
+		/** Configure Regular Channel (PA2 / BEMFW / Phase W)
+		*/
+		sConfig.Channel = _getADCChannel(analogInputToPinName(A_BEMFW), ADC2);
+		sConfig.Rank = ADC_REGULAR_RANK_3;
+		sConfig.SamplingTime = ADC_SAMPLETIME_6CYCLES_5;
+		if (HAL_ADC_ConfigChannel(hadc2, &sConfig) != HAL_OK)
+		{
+			SIMPLEFOC_DEBUG("HAL_ADC_ConfigChannel failed!");
+		}
+	}
+
+	/** Configure Regular Channel (PF1 / Mosfet temperature)
+	*/
+	sConfig.Channel = _getADCChannel(analogInputToPinName(A_TEMPERATURE), ADC2);
+	sConfig.Rank = read_bemf ? ADC_REGULAR_RANK_4 : ADC_REGULAR_RANK_3;
+	sConfig.SamplingTime = ADC_SAMPLETIME_47CYCLES_5;
+	if (HAL_ADC_ConfigChannel(hadc2, &sConfig) != HAL_OK)
+	{
+		SIMPLEFOC_DEBUG("HAL_ADC_ConfigChannel failed!");
+	}
+	return hadc2->Init.NbrOfConversion;
+}
+
+uint16_t Phoque1_CurrentSense::readRaw(const int pin)
+{
+    switch (pin)
+	{
+	case A_CURRU_H:
+	case -1:
+		return adc2_buffer[0];
+	case A_CURRV_H:
+	case -2:
+		return adc2_buffer[1];
+	case A_CURRW_H:
+	case -3:
+		return adc1_buffer[0];
+
+	case A_BEMFU:
+		return adc1_buffer[1];
+	case A_BEMFV:
+		return adc1_buffer[2];
+	case A_BEMFW:
+		return adc2_buffer[2];
+
+	case A_POTENTIOMETER:
+		return adc1_buffer[2+read_bemf*2];
+	case A_TEMPERATURE:
+		return adc2_buffer[2+read_bemf];
+	case A_VBUS:
+		return adc1_buffer[1+read_bemf*2];
+	default:
+		return 0;
+	}
+}
+
+#endif

--- a/src/current_sense/phoque1/Phoque1_CurrentSense.hpp
+++ b/src/current_sense/phoque1/Phoque1_CurrentSense.hpp
@@ -6,10 +6,6 @@
 
 class Phoque1_CurrentSense : public Phoque_CurrentSense
 {
-private:
-	volatile uint16_t *adc1_buffer = nullptr;
-	volatile uint16_t *adc2_buffer = nullptr;
-	bool read_bemf;
 public:
 	Phoque1_CurrentSense(float shunt_resistor, float gain, bool read_bemf=false);
 	Phoque1_CurrentSense(float mVpA, bool read_bemf=false);

--- a/src/current_sense/phoque1/Phoque1_CurrentSense.hpp
+++ b/src/current_sense/phoque1/Phoque1_CurrentSense.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#if defined(ARDUINO_PHOQUE1)
+
+#include "current_sense/phoque/Phoque_CurrentSense.hpp"
+
+class Phoque1_CurrentSense : public Phoque_CurrentSense
+{
+private:
+	volatile uint16_t *adc1_buffer = nullptr;
+	volatile uint16_t *adc2_buffer = nullptr;
+	bool read_bemf;
+public:
+	Phoque1_CurrentSense(float shunt_resistor, float gain, bool read_bemf=false);
+	Phoque1_CurrentSense(float mVpA, bool read_bemf=false);
+	~Phoque1_CurrentSense();
+
+	uint16_t readRaw(const int pin);
+
+private:
+    void Opamp_Init();
+	int ADC1_Init(ADC_HandleTypeDef* hadc1);
+	int ADC2_Init(ADC_HandleTypeDef* hadc2);
+};
+
+#endif

--- a/src/current_sense/phoque1/Phoque1_CurrentSense.hpp
+++ b/src/current_sense/phoque1/Phoque1_CurrentSense.hpp
@@ -11,12 +11,25 @@ public:
 	Phoque1_CurrentSense(float mVpA, bool read_bemf=false);
 	~Phoque1_CurrentSense();
 
-	uint16_t readRaw(const int pin);
+	virtual uint16_t readRaw(const int pin) const override;
 
-private:
-    void Opamp_Init();
-	int ADC1_Init(ADC_HandleTypeDef* hadc1);
-	int ADC2_Init(ADC_HandleTypeDef* hadc2);
+	static constexpr float compute_equivalent_shunt(float rshunt = 3e-3f, float rline = 1.5e3f, float rup = 2.2e3f, float rdown = 22e3f)
+	{
+		float req1 = rup*rdown/(rup+rdown);
+		return rshunt*req1/(rshunt+rline+req1);
+	}
+
+protected:
+    virtual void OPAMP_Init() override;
+
+	//duration of the sampling for adc1, in ADC clock cycles
+	virtual int get_adc1_important_duration() override;
+	//duration of the sampling for adc2, in ADC clock cycles
+	virtual int get_adc2_important_duration() override;
+	virtual int ADC1_Init(ADC_HandleTypeDef* hadc1) override;
+	virtual int ADC2_Init(ADC_HandleTypeDef* hadc2) override;
+
+	void clear_currents() final;
 };
 
 #endif

--- a/src/current_sense/phoque2a/Phoque2a_CurrentSense.cpp
+++ b/src/current_sense/phoque2a/Phoque2a_CurrentSense.cpp
@@ -29,6 +29,9 @@ Phoque2a_CurrentSense::~Phoque2a_CurrentSense()
 int Phoque2a_CurrentSense::ADC1_Init(ADC_HandleTypeDef* hadc1)
 {
 	ADC_ChannelConfTypeDef sConfig = {0};
+	sConfig.SingleDiff = ADC_SINGLE_ENDED;
+	sConfig.OffsetNumber = ADC_OFFSET_NONE;
+	sConfig.Offset = 0;
 
 	hadc1->Init.NbrOfConversion += 3 + read_bemf * 2;
 
@@ -39,9 +42,6 @@ int Phoque2a_CurrentSense::ADC1_Init(ADC_HandleTypeDef* hadc1)
 	sConfig.Channel = _getADCChannel(analogInputToPinName(A_CURRU), ADC1); //ADC_CHANNEL_2;
 	sConfig.Rank = ADC_REGULAR_RANK_1;
 	sConfig.SamplingTime = ADC_SAMPLETIME_6CYCLES_5;
-	sConfig.SingleDiff = ADC_SINGLE_ENDED;
-	sConfig.OffsetNumber = ADC_OFFSET_NONE;
-	sConfig.Offset = 0;
 	if (HAL_ADC_ConfigChannel(hadc1, &sConfig) != HAL_OK)
 	{
 		SIMPLEFOC_DEBUG("HAL_ADC_ConfigChannel failed!");
@@ -54,9 +54,6 @@ int Phoque2a_CurrentSense::ADC1_Init(ADC_HandleTypeDef* hadc1)
 		sConfig.Channel = _getADCChannel(analogInputToPinName(A_BEMFV), ADC1); //ADC_CHANNEL_15;
 		sConfig.Rank = ADC_REGULAR_RANK_2;
 		sConfig.SamplingTime = ADC_SAMPLETIME_6CYCLES_5;
-		sConfig.SingleDiff = ADC_SINGLE_ENDED;
-		sConfig.OffsetNumber = ADC_OFFSET_NONE;
-		sConfig.Offset = 0;
 		if (HAL_ADC_ConfigChannel(hadc1, &sConfig) != HAL_OK)
 		{
 			SIMPLEFOC_DEBUG("HAL_ADC_ConfigChannel failed!");
@@ -67,9 +64,6 @@ int Phoque2a_CurrentSense::ADC1_Init(ADC_HandleTypeDef* hadc1)
 		sConfig.Channel = _getADCChannel(analogInputToPinName(A_BEMFW), ADC1); //ADC_CHANNEL_12;
 		sConfig.Rank = ADC_REGULAR_RANK_3;
 		sConfig.SamplingTime = ADC_SAMPLETIME_6CYCLES_5;
-		sConfig.SingleDiff = ADC_SINGLE_ENDED;
-		sConfig.OffsetNumber = ADC_OFFSET_NONE;
-		sConfig.Offset = 0;
 		if (HAL_ADC_ConfigChannel(hadc1, &sConfig) != HAL_OK)
 		{
 			SIMPLEFOC_DEBUG("HAL_ADC_ConfigChannel failed!");
@@ -83,9 +77,6 @@ int Phoque2a_CurrentSense::ADC1_Init(ADC_HandleTypeDef* hadc1)
 	sConfig.Channel = _getADCChannel(analogInputToPinName(A_TEMPERATURE), ADC1); //ADC_CHANNEL_11;
 	sConfig.Rank = read_bemf ? ADC_REGULAR_RANK_4 : ADC_REGULAR_RANK_2;
 	sConfig.SamplingTime = ADC_SAMPLETIME_47CYCLES_5;
-	sConfig.SingleDiff = ADC_SINGLE_ENDED;
-	sConfig.OffsetNumber = ADC_OFFSET_NONE;
-	sConfig.Offset = 0;
 	if (HAL_ADC_ConfigChannel(hadc1, &sConfig) != HAL_OK)
 	{
 		SIMPLEFOC_DEBUG("HAL_ADC_ConfigChannel failed!");
@@ -96,9 +87,6 @@ int Phoque2a_CurrentSense::ADC1_Init(ADC_HandleTypeDef* hadc1)
 	sConfig.Channel = _getADCChannel(analogInputToPinName(A_VBUS), ADC1); //ADC_CHANNEL_4;
 	sConfig.Rank = read_bemf ? ADC_REGULAR_RANK_5 : ADC_REGULAR_RANK_3;
 	sConfig.SamplingTime = ADC_SAMPLETIME_47CYCLES_5;
-	sConfig.SingleDiff = ADC_SINGLE_ENDED;
-	sConfig.OffsetNumber = ADC_OFFSET_NONE;
-	sConfig.Offset = 0;
 	if (HAL_ADC_ConfigChannel(hadc1, &sConfig) != HAL_OK)
 	{
 		SIMPLEFOC_DEBUG("HAL_ADC_ConfigChannel failed!");
@@ -109,6 +97,9 @@ int Phoque2a_CurrentSense::ADC1_Init(ADC_HandleTypeDef* hadc1)
 int Phoque2a_CurrentSense::ADC2_Init(ADC_HandleTypeDef* hadc2)
 {
 	ADC_ChannelConfTypeDef sConfig = {0};
+	sConfig.SingleDiff = ADC_SINGLE_ENDED;
+	sConfig.OffsetNumber = ADC_OFFSET_NONE;
+	sConfig.Offset = 0;
 
 	hadc2->Init.NbrOfConversion += 3 + read_bemf;
 
@@ -119,9 +110,6 @@ int Phoque2a_CurrentSense::ADC2_Init(ADC_HandleTypeDef* hadc2)
 	sConfig.Channel = _getADCChannel(analogInputToPinName(A_CURRV), ADC2); //ADC_CHANNEL_5;
 	sConfig.Rank = ADC_REGULAR_RANK_1;
 	sConfig.SamplingTime = ADC_SAMPLETIME_6CYCLES_5;
-	sConfig.SingleDiff = ADC_SINGLE_ENDED;
-	sConfig.OffsetNumber = ADC_OFFSET_NONE;
-	sConfig.Offset = 0;
 	if (HAL_ADC_ConfigChannel(hadc2, &sConfig) != HAL_OK)
 	{
 		SIMPLEFOC_DEBUG("HAL_ADC_ConfigChannel failed!");
@@ -131,9 +119,6 @@ int Phoque2a_CurrentSense::ADC2_Init(ADC_HandleTypeDef* hadc2)
 	sConfig.Channel = _getADCChannel(analogInputToPinName(A_CURRW), ADC2); //ADC_CHANNEL_12;
 	sConfig.Rank = ADC_REGULAR_RANK_2;
 	sConfig.SamplingTime = ADC_SAMPLETIME_6CYCLES_5;
-	sConfig.SingleDiff = ADC_SINGLE_ENDED;
-	sConfig.OffsetNumber = ADC_OFFSET_NONE;
-	sConfig.Offset = 0;
 	if (HAL_ADC_ConfigChannel(hadc2, &sConfig) != HAL_OK)
 	{
 		SIMPLEFOC_DEBUG("HAL_ADC_ConfigChannel failed!");
@@ -146,9 +131,6 @@ int Phoque2a_CurrentSense::ADC2_Init(ADC_HandleTypeDef* hadc2)
 		sConfig.Channel = _getADCChannel(analogInputToPinName(A_BEMFU), ADC2); //ADC_CHANNEL_1;
 		sConfig.Rank = ADC_REGULAR_RANK_3;
 		sConfig.SamplingTime = ADC_SAMPLETIME_6CYCLES_5;
-		sConfig.SingleDiff = ADC_SINGLE_ENDED;
-		sConfig.OffsetNumber = ADC_OFFSET_NONE;
-		sConfig.Offset = 0;
 		if (HAL_ADC_ConfigChannel(hadc2, &sConfig) != HAL_OK)
 		{
 			SIMPLEFOC_DEBUG("HAL_ADC_ConfigChannel failed!");
@@ -160,9 +142,6 @@ int Phoque2a_CurrentSense::ADC2_Init(ADC_HandleTypeDef* hadc2)
 	sConfig.Channel = _getADCChannel(analogInputToPinName(A_POTENTIOMETER), ADC2); //ADC_CHANNEL_17;
 	sConfig.Rank = read_bemf ? ADC_REGULAR_RANK_4 : ADC_REGULAR_RANK_3;
 	sConfig.SamplingTime = ADC_SAMPLETIME_47CYCLES_5;
-	sConfig.SingleDiff = ADC_SINGLE_ENDED;
-	sConfig.OffsetNumber = ADC_OFFSET_NONE;
-	sConfig.Offset = 0;
 	if (HAL_ADC_ConfigChannel(hadc2, &sConfig) != HAL_OK)
 	{
 		SIMPLEFOC_DEBUG("HAL_ADC_ConfigChannel failed!");

--- a/src/current_sense/phoque2a/Phoque2a_CurrentSense.cpp
+++ b/src/current_sense/phoque2a/Phoque2a_CurrentSense.cpp
@@ -26,6 +26,20 @@ Phoque2a_CurrentSense::~Phoque2a_CurrentSense()
 {
 }
 
+#define SAMPLETIME_IMPORTANT ADC_SAMPLETIME_6CYCLES_5
+#define SAMPLETIME_PERIPHERAL ADC_SAMPLETIME_47CYCLES_5
+
+int Phoque2a_CurrentSense::get_adc1_important_duration()
+{
+	return (read_bemf ? 2:0) * get_conversion_duration(6) + 6;
+}
+
+int Phoque2a_CurrentSense::get_adc2_important_duration()
+{
+	return (read_bemf ? 2:1) * get_conversion_duration(6) + 6;
+}
+
+
 int Phoque2a_CurrentSense::ADC1_Init(ADC_HandleTypeDef* hadc1)
 {
 	ADC_ChannelConfTypeDef sConfig = {0};
@@ -41,7 +55,7 @@ int Phoque2a_CurrentSense::ADC1_Init(ADC_HandleTypeDef* hadc1)
 	*/
 	sConfig.Channel = _getADCChannel(analogInputToPinName(A_CURRU), ADC1); //ADC_CHANNEL_2;
 	sConfig.Rank = ADC_REGULAR_RANK_1;
-	sConfig.SamplingTime = ADC_SAMPLETIME_6CYCLES_5;
+	sConfig.SamplingTime = SAMPLETIME_IMPORTANT;
 	if (HAL_ADC_ConfigChannel(hadc1, &sConfig) != HAL_OK)
 	{
 		SIMPLEFOC_DEBUG("HAL_ADC_ConfigChannel failed!");
@@ -53,7 +67,7 @@ int Phoque2a_CurrentSense::ADC1_Init(ADC_HandleTypeDef* hadc1)
 		*/
 		sConfig.Channel = _getADCChannel(analogInputToPinName(A_BEMFV), ADC1); //ADC_CHANNEL_15;
 		sConfig.Rank = ADC_REGULAR_RANK_2;
-		sConfig.SamplingTime = ADC_SAMPLETIME_6CYCLES_5;
+		sConfig.SamplingTime = SAMPLETIME_IMPORTANT;
 		if (HAL_ADC_ConfigChannel(hadc1, &sConfig) != HAL_OK)
 		{
 			SIMPLEFOC_DEBUG("HAL_ADC_ConfigChannel failed!");
@@ -63,7 +77,7 @@ int Phoque2a_CurrentSense::ADC1_Init(ADC_HandleTypeDef* hadc1)
 		*/
 		sConfig.Channel = _getADCChannel(analogInputToPinName(A_BEMFW), ADC1); //ADC_CHANNEL_12;
 		sConfig.Rank = ADC_REGULAR_RANK_3;
-		sConfig.SamplingTime = ADC_SAMPLETIME_6CYCLES_5;
+		sConfig.SamplingTime = SAMPLETIME_IMPORTANT;
 		if (HAL_ADC_ConfigChannel(hadc1, &sConfig) != HAL_OK)
 		{
 			SIMPLEFOC_DEBUG("HAL_ADC_ConfigChannel failed!");
@@ -76,7 +90,7 @@ int Phoque2a_CurrentSense::ADC1_Init(ADC_HandleTypeDef* hadc1)
 	*/
 	sConfig.Channel = _getADCChannel(analogInputToPinName(A_TEMPERATURE), ADC1); //ADC_CHANNEL_11;
 	sConfig.Rank = read_bemf ? ADC_REGULAR_RANK_4 : ADC_REGULAR_RANK_2;
-	sConfig.SamplingTime = ADC_SAMPLETIME_47CYCLES_5;
+	sConfig.SamplingTime = SAMPLETIME_PERIPHERAL;
 	if (HAL_ADC_ConfigChannel(hadc1, &sConfig) != HAL_OK)
 	{
 		SIMPLEFOC_DEBUG("HAL_ADC_ConfigChannel failed!");
@@ -86,7 +100,7 @@ int Phoque2a_CurrentSense::ADC1_Init(ADC_HandleTypeDef* hadc1)
 	*/
 	sConfig.Channel = _getADCChannel(analogInputToPinName(A_VBUS), ADC1); //ADC_CHANNEL_4;
 	sConfig.Rank = read_bemf ? ADC_REGULAR_RANK_5 : ADC_REGULAR_RANK_3;
-	sConfig.SamplingTime = ADC_SAMPLETIME_47CYCLES_5;
+	sConfig.SamplingTime = SAMPLETIME_PERIPHERAL;
 	if (HAL_ADC_ConfigChannel(hadc1, &sConfig) != HAL_OK)
 	{
 		SIMPLEFOC_DEBUG("HAL_ADC_ConfigChannel failed!");
@@ -109,7 +123,7 @@ int Phoque2a_CurrentSense::ADC2_Init(ADC_HandleTypeDef* hadc2)
 	*/
 	sConfig.Channel = _getADCChannel(analogInputToPinName(A_CURRV), ADC2); //ADC_CHANNEL_5;
 	sConfig.Rank = ADC_REGULAR_RANK_1;
-	sConfig.SamplingTime = ADC_SAMPLETIME_6CYCLES_5;
+	sConfig.SamplingTime = SAMPLETIME_IMPORTANT;
 	if (HAL_ADC_ConfigChannel(hadc2, &sConfig) != HAL_OK)
 	{
 		SIMPLEFOC_DEBUG("HAL_ADC_ConfigChannel failed!");
@@ -118,7 +132,7 @@ int Phoque2a_CurrentSense::ADC2_Init(ADC_HandleTypeDef* hadc2)
 	*/
 	sConfig.Channel = _getADCChannel(analogInputToPinName(A_CURRW), ADC2); //ADC_CHANNEL_12;
 	sConfig.Rank = ADC_REGULAR_RANK_2;
-	sConfig.SamplingTime = ADC_SAMPLETIME_6CYCLES_5;
+	sConfig.SamplingTime = SAMPLETIME_IMPORTANT;
 	if (HAL_ADC_ConfigChannel(hadc2, &sConfig) != HAL_OK)
 	{
 		SIMPLEFOC_DEBUG("HAL_ADC_ConfigChannel failed!");
@@ -130,7 +144,7 @@ int Phoque2a_CurrentSense::ADC2_Init(ADC_HandleTypeDef* hadc2)
 		*/
 		sConfig.Channel = _getADCChannel(analogInputToPinName(A_BEMFU), ADC2); //ADC_CHANNEL_1;
 		sConfig.Rank = ADC_REGULAR_RANK_3;
-		sConfig.SamplingTime = ADC_SAMPLETIME_6CYCLES_5;
+		sConfig.SamplingTime = SAMPLETIME_IMPORTANT;
 		if (HAL_ADC_ConfigChannel(hadc2, &sConfig) != HAL_OK)
 		{
 			SIMPLEFOC_DEBUG("HAL_ADC_ConfigChannel failed!");
@@ -141,7 +155,7 @@ int Phoque2a_CurrentSense::ADC2_Init(ADC_HandleTypeDef* hadc2)
 	*/
 	sConfig.Channel = _getADCChannel(analogInputToPinName(A_POTENTIOMETER), ADC2); //ADC_CHANNEL_17;
 	sConfig.Rank = read_bemf ? ADC_REGULAR_RANK_4 : ADC_REGULAR_RANK_3;
-	sConfig.SamplingTime = ADC_SAMPLETIME_47CYCLES_5;
+	sConfig.SamplingTime = SAMPLETIME_PERIPHERAL;
 	if (HAL_ADC_ConfigChannel(hadc2, &sConfig) != HAL_OK)
 	{
 		SIMPLEFOC_DEBUG("HAL_ADC_ConfigChannel failed!");
@@ -149,7 +163,7 @@ int Phoque2a_CurrentSense::ADC2_Init(ADC_HandleTypeDef* hadc2)
 	return hadc2->Init.NbrOfConversion;
 }
 
-uint16_t Phoque2a_CurrentSense::readRaw(const int pin)
+inline uint16_t Phoque2a_CurrentSense::readRaw(const int pin) const
 {
 	switch (pin)
 	{
@@ -179,6 +193,13 @@ uint16_t Phoque2a_CurrentSense::readRaw(const int pin)
 	default:
 		return 0;
 	}
+}
+
+inline void Phoque2a_CurrentSense::clear_currents()
+{
+	adc1_buffer[0] = UINT16_MAX;
+	adc2_buffer[0] = UINT16_MAX;
+	adc2_buffer[1] = UINT16_MAX;
 }
 
 #endif

--- a/src/current_sense/phoque2a/Phoque2a_CurrentSense.hpp
+++ b/src/current_sense/phoque2a/Phoque2a_CurrentSense.hpp
@@ -13,11 +13,16 @@ public:
 	Phoque2a_CurrentSense(float mVpA, bool read_bemf=false);
 	virtual ~Phoque2a_CurrentSense();
 
-	virtual uint16_t readRaw(const int pin) override;
+	virtual uint16_t readRaw(const int pin) const override;
 
 private:
+
+	virtual int get_adc1_important_duration() override;
+	virtual int get_adc2_important_duration() override;
 	virtual int ADC1_Init(ADC_HandleTypeDef* hadc1) override;
 	virtual int ADC2_Init(ADC_HandleTypeDef* hadc2) override;
+
+	void clear_currents() final;
 };
 
 #endif

--- a/src/current_sense/phoque2a/Phoque2a_CurrentSense.hpp
+++ b/src/current_sense/phoque2a/Phoque2a_CurrentSense.hpp
@@ -8,10 +8,6 @@ class Phoque2a_CurrentSense : public Phoque_CurrentSense
 {
 	//Current sense for the Phoque2 board
 	//for best performance, center modulation should be off
-private:
-	volatile uint16_t *adc1_buffer = nullptr;
-	volatile uint16_t *adc2_buffer = nullptr;
-	bool read_bemf;
 public:
 	Phoque2a_CurrentSense(float shunt_resistor, float gain, bool read_bemf=false);
 	Phoque2a_CurrentSense(float mVpA, bool read_bemf=false);

--- a/src/drivers/stspin32g4/STSPIN32G4.h
+++ b/src/drivers/stspin32g4/STSPIN32G4.h
@@ -5,6 +5,7 @@
 
 #ifdef ARDUINO_GENERIC_G431VBTX
 
+#include "stm32g4xx_hal_i2c.h"
 #include "Wire.h"
 #include "drivers/BLDCDriver6PWM.h"
 


### PR DESCRIPTION
Publishing this because i'm doing a small validation run of Phoque1 (based on stspin32g4), and it's super similar to what is in BG431-ESC1.

This is untested code as of now.