### PR TITLE
Fix TMC6200 driver: spi->end() should be spi->endTransaction()

### DIFF
--- a/src/drivers/tmc6200/TMC6200.cpp
+++ b/src/drivers/tmc6200/TMC6200.cpp
@@ -180,7 +180,7 @@ uint32_t TMC6200Driver::readRegister(uint8_t addr) {
     value |= (spi->transfer(0x00) << 8);
     value |= (spi->transfer(0x00) << 0);
 
-    spi->end();
+    spi->endTransaction();
     digitalWrite(csPin, HIGH);
 
     return value;
@@ -199,7 +199,7 @@ void TMC6200Driver::writeRegister(uint8_t addr, uint32_t data) {
     spi->transfer(0xFF & (data >> 8));
     spi->transfer(0xFF & (data >> 0));
 
-    spi->end();
+    spi->endTransaction();
     digitalWrite(csPin, HIGH);
 }
 


### PR DESCRIPTION
Both `readRegister()` and `writeRegister()` in TMC6200.cpp pair `spi->beginTransaction(settings)` with `spi->end()` instead of `spi->endTransaction()`. `end()` fully de-initializes the SPI peripheral (on the STM32 core it calls `spi_deinit()`), while `endTransaction()` is just supposed to release the transaction lock so the bus can be shared. Every other driver in this repo (drv8316, drv832x, drv8376) gets this right and uses `endTransaction()`.

On the STM32 Arduino core this is worse than "just needs a fresh begin() before the bus is used again": `SPIClass::beginTransaction()` only re-initializes the hardware when the `SPISettings` passed in differ from the ones cached from the previous call. TMC6200Driver reuses the same `settings` member for every call, so as soon as `readRegister()` tears the peripheral down with `end()`, the very next `beginTransaction()` (e.g. the write half of the read-modify-write in `setDriverState()`) sees identical settings and silently skips re-init, and the write goes out over a de-initialized peripheral with no error raised.

I confirmed this by pulling the actual `SPIClass::configSpi/begin/beginTransaction/end/endTransaction` implementation from Arduino_Core_STM32 and reproducing the exact call sequence (`readRegister()` then `writeRegister()`, as `setDriverState()` does) in a small standalone harness outside the Arduino toolchain - the peripheral ends up de-initialized after the very first register write following a read.

This was reported in #66 back in October, and the maintainer agreed with the fix ("I will fix it for the next release") but it looks like it never got applied. It's a straight two-line swap, no behavior change intended anywhere else.
