### PR TITLE
esp32hwencoder: document that the pulse and ctrl pins are passed crossed

### DIFF
--- a/src/encoders/esp32hwencoder/ESP32HWEncoder.cpp
+++ b/src/encoders/esp32hwencoder/ESP32HWEncoder.cpp
@@ -19,6 +19,10 @@ ESP32HWEncoder::ESP32HWEncoder(int pinA, int pinB, int32_t ppr, int pinI)
 
     cpr = ppr * 4; // 4x for quadrature
 
+    // NOTE: despite their names, these two fields are passed CROSSED into
+    // pcnt_set_pin() in init(). Pin A ends up on the PULSE input, not the
+    // control input. See the comment in init() before concluding that A and B
+    // have been given the wrong roles here.
     pcnt_config.ctrl_gpio_num =  _pinA;
     pcnt_config.pulse_gpio_num = _pinB;
     pcnt_config.counter_l_lim = INT16_MIN;
@@ -90,6 +94,18 @@ void ESP32HWEncoder::init()
     if (initialized)
     {
         // Set up the PCNT peripheral
+        //
+        // pcnt_set_pin() takes (unit, channel, pulse_io, ctrl_io), so the two
+        // config fields are passed CROSSED with respect to their names:
+        // channel 0 gets pin A on PULSE and pin B on CONTROL, channel 1 the
+        // reverse. That is the standard quadrature arrangement, and combined
+        // with the pcnt_set_mode() calls below it gives the standard direction
+        // convention: A leading B counts up.
+        //
+        // Spelled out because the constructor assigns ctrl_gpio_num = _pinA,
+        // which reads like the roles are swapped. They are not -- the crossing
+        // here cancels it, and swapping the fields in the constructor would
+        // invert the counting direction rather than correct it. See issue #101.
         pcnt_set_pin(pcnt_config.unit, PCNT_CHANNEL_0, pcnt_config.ctrl_gpio_num, pcnt_config.pulse_gpio_num);
         pcnt_set_pin(pcnt_config.unit, PCNT_CHANNEL_1, pcnt_config.pulse_gpio_num, pcnt_config.ctrl_gpio_num);
         pcnt_set_mode(pcnt_config.unit, PCNT_CHANNEL_0, PCNT_COUNT_INC, PCNT_COUNT_DEC, PCNT_MODE_REVERSE, PCNT_MODE_KEEP);


### PR DESCRIPTION

Comment-only change to `ESP32HWEncoder.cpp`. No behaviour change.

The constructor assigns `pcnt_config.ctrl_gpio_num = _pinA` and `pcnt_config.pulse_gpio_num = _pinB`, which reads as though pin A has been given the control role and pin B the pulse role — the opposite of the usual quadrature arrangement. It is not what actually happens. `pcnt_set_pin()` takes `(unit, channel, pulse_io, ctrl_io)`, and `init()` passes those two fields crossed, so channel 0 ends up with pin A on PULSE and pin B on CONTROL, and channel 1 the reverse. That is the standard arrangement, and together with the `pcnt_set_mode()` calls it produces the standard direction convention — A leading B counts up.

Walking the four edges of an A-leads-B cycle, `(A,B)` going `(0,0) -> (1,0) -> (1,1) -> (0,1) -> (0,0)`:

| Edge | Pulse channel | Control level | Action | Delta |
|---|---|---|---|---|
| A rises | ch0 | B low, KEEP | pos_mode INC | +1 |
| B rises | ch1 | A high, REVERSE | pos_mode DEC reversed | +1 |
| A falls | ch0 | B high, REVERSE | neg_mode DEC reversed | +1 |
| B falls | ch1 | A low, KEEP | neg_mode INC | +1 |

Net +4 per cycle, so A leading B counts up. The driver is correct as it stands.

I filed #101 against this code claiming the roles were swapped, having read only the constructor. That claim was wrong and I closed it. The reason the mistake is easy to make is that the field names describe the opposite of the final configuration, and nothing in the file says so. Worse, the apparent "fix" — swapping the two fields in the constructor — silently inverts the counting direction while everything still counts perfectly at the correct scale, which is a hard fault to spot.

This PR adds two comments: one at the constructor pointing forward to `init()`, and one at the `pcnt_set_pin()` calls explaining the crossing and stating the resulting direction convention. Nothing else is touched.